### PR TITLE
feat(donation): finish copy-to-clipboard for wallet addresses (closes #56, #30)

### DIFF
--- a/src/components/DonationSection.jsx
+++ b/src/components/DonationSection.jsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
-import { Heart, Wallet, ArrowUpRight } from 'lucide-react';
+import { Heart, Wallet, ArrowUpRight, Copy, Check } from 'lucide-react';
 import { DONATION_LINKS, CRYPTO_WALLETS, AFFILIATE_LINKS } from '../config/sponsorData';
+import { useClipboard } from '../utils/useClipboard';
 
 /**
  * 捐赠区块（首页展示）
@@ -8,6 +9,7 @@ import { DONATION_LINKS, CRYPTO_WALLETS, AFFILIATE_LINKS } from '../config/spons
  */
 const DonationSection = () => {
   const { t } = useTranslation();
+  const { copied, copy } = useClipboard();
   return (
     <div className="max-w-3xl mx-auto mb-16">
       <h2 className="text-2xl font-bold text-white text-center mb-2">{t('donation.title')}</h2>
@@ -76,9 +78,13 @@ const DonationSection = () => {
           <span>{t('donation.cryptoLabel')}</span>
         </div>
         {CRYPTO_WALLETS.map((wallet) => (
-          <div
+          <button
             key={wallet.chain}
-            className="flex items-start gap-3 p-4 bg-slate-800 border border-slate-700 rounded-xl"
+            type="button"
+            onClick={() => copy(wallet.address)}
+            title={t('donation.copyAddress')}
+            className="w-full flex items-start gap-3 p-4 bg-slate-800 border border-slate-700 rounded-xl
+              text-left cursor-pointer hover:border-cyan-500/40 transition-all group"
           >
             <div
               className="px-2.5 py-1 bg-slate-700 rounded-md text-xs font-mono font-bold
@@ -86,11 +92,21 @@ const DonationSection = () => {
             >
               {wallet.chain}
             </div>
-            <div className="min-w-0">
+            <div className="min-w-0 flex-1">
               <div className="text-xs text-slate-400 mb-1">{wallet.network}</div>
               <div className="font-mono text-xs text-slate-200 break-all">{wallet.address}</div>
             </div>
-          </div>
+            <div className="shrink-0 mt-0.5">
+              {copied === wallet.address ? (
+                <span className="flex items-center gap-1 text-xs text-green-400">
+                  <Check className="w-3.5 h-3.5" />
+                  {t('donation.copied')}
+                </span>
+              ) : (
+                <Copy className="w-3.5 h-3.5 text-slate-500 group-hover:text-cyan-400 transition-colors" />
+              )}
+            </div>
+          </button>
         ))}
       </div>
     </div>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -165,7 +165,9 @@
   "donation": {
     "title": "Support This Project",
     "subtitle": "This tutorial is completely free and open source. If it has been helpful to you, please consider supporting the author to keep it updated ✨",
-    "cryptoLabel": "Crypto tips"
+    "cryptoLabel": "Crypto tips",
+    "copyAddress": "Click to copy address",
+    "copied": "Copied!"
   },
   "sponsor": {
     "title": "Our Sponsors",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -165,7 +165,9 @@
   "donation": {
     "title": "支持本项目",
     "subtitle": "本教程完全免费开源，如果对你有帮助，欢迎支持作者持续更新 ✨",
-    "cryptoLabel": "加密货币打赏"
+    "cryptoLabel": "加密货币打赏",
+    "copyAddress": "点击复制地址",
+    "copied": "已复制！"
   },
   "sponsor": {
     "title": "我们的赞助商",

--- a/src/pages/SupportPage.jsx
+++ b/src/pages/SupportPage.jsx
@@ -1,9 +1,10 @@
 import { Link, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Heart, Wallet, Coffee, ArrowLeft, Star, ArrowUpRight } from 'lucide-react';
+import { Heart, Wallet, Coffee, ArrowLeft, Star, ArrowUpRight, Copy, Check } from 'lucide-react';
 import { DONATION_LINKS, CRYPTO_WALLETS, SPONSORS, AFFILIATE_LINKS } from '../config/sponsorData';
 import SeoHead from '../components/SeoHead';
 import LanguageSwitcher from '../components/LanguageSwitcher';
+import { useClipboard } from '../utils/useClipboard';
 
 /**
  * 支持页面 — 展示捐赠渠道、加密货币钱包地址和赞助商信息
@@ -11,6 +12,7 @@ import LanguageSwitcher from '../components/LanguageSwitcher';
 const SupportPage = () => {
   const { lang } = useParams();
   const { t } = useTranslation();
+  const { copied, copy } = useClipboard();
 
   const siteUrl = 'https://beihaili.github.io/Get-Started-with-Web3/';
   const canonicalUrl = `${siteUrl}${lang}/support`;
@@ -103,9 +105,13 @@ const SupportPage = () => {
           </h2>
           <div className="space-y-3">
             {CRYPTO_WALLETS.map((wallet) => (
-              <div
+              <button
                 key={wallet.chain}
-                className="flex items-start gap-4 p-5 bg-white/60 dark:bg-slate-900/60 border border-slate-200/50 dark:border-slate-700/50 rounded-xl"
+                type="button"
+                onClick={() => copy(wallet.address)}
+                title={t('donation.copyAddress')}
+                className="w-full flex items-start gap-4 p-5 bg-white/60 dark:bg-slate-900/60 border border-slate-200/50 dark:border-slate-700/50 rounded-xl
+                  text-left cursor-pointer hover:border-cyan-500/40 transition-all group"
               >
                 <div
                   className="px-3 py-1.5 bg-slate-100 dark:bg-slate-800 rounded-lg text-sm font-mono font-bold
@@ -113,7 +119,7 @@ const SupportPage = () => {
                 >
                   {wallet.chain}
                 </div>
-                <div className="min-w-0">
+                <div className="min-w-0 flex-1">
                   <div className="text-xs text-slate-500 dark:text-slate-400 mb-1">
                     {wallet.network}
                   </div>
@@ -121,7 +127,17 @@ const SupportPage = () => {
                     {wallet.address}
                   </div>
                 </div>
-              </div>
+                <div className="shrink-0 mt-1">
+                  {copied === wallet.address ? (
+                    <span className="flex items-center gap-1 text-xs text-green-400">
+                      <Check className="w-4 h-4" />
+                      {t('donation.copied')}
+                    </span>
+                  ) : (
+                    <Copy className="w-4 h-4 text-slate-500 group-hover:text-cyan-400 transition-colors" />
+                  )}
+                </div>
+              </button>
             ))}
           </div>
         </section>

--- a/src/utils/useClipboard.js
+++ b/src/utils/useClipboard.js
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+
+/**
+ * Copies text to the clipboard and tracks which value was most recently copied.
+ *
+ * Falls back to a hidden `<textarea>` + `execCommand('copy')` for older browsers
+ * or insecure (non-HTTPS) contexts where the async Clipboard API is unavailable.
+ *
+ * @param {number} resetMs - How long (ms) to keep `copied` set before clearing.
+ * @returns {{ copied: string|null, copy: (text: string) => Promise<void> }}
+ */
+export function useClipboard(resetMs = 2000) {
+  const [copied, setCopied] = useState(null);
+
+  const copy = async (text) => {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      const textarea = document.createElement('textarea');
+      textarea.value = text;
+      // Keep the element off-screen so it doesn't flash during fallback copy.
+      textarea.style.position = 'fixed';
+      textarea.style.left = '-9999px';
+      textarea.setAttribute('readonly', '');
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+    }
+    setCopied(text);
+    setTimeout(() => setCopied(null), resetMs);
+  };
+
+  return { copied, copy };
+}


### PR DESCRIPTION
## Summary
Takes over and finishes @locchung's PR #56 (inactive for 3 weeks).

- **Feature**: Click any wallet card on the Landing donation section or `/support` page to copy the address. Visual feedback shows a green "Copied!" label for 2s.
- **Fallback**: Uses async `navigator.clipboard` when available, with a hidden `<textarea>` + `execCommand` fallback for older/insecure contexts.
- **DRY**: Extracted a small `useClipboard` hook (`src/utils/useClipboard.js`) so both components share the same logic.

## What this adds on top of #56
1. Resolved merge conflicts against `main` (dark-mode classes, `AFFILIATE_LINKS` import)
2. Replaced hardcoded English strings with `t('donation.copyAddress')` / `t('donation.copied')` — added keys to `en.json` and `zh.json`
3. Positioned the fallback `<textarea>` with `position: fixed; left: -9999px` so it doesn't flash during copy
4. Extracted the duplicated `handleCopy` into a reusable `useClipboard` hook
5. Swapped the wrapper from `<div onClick>` → `<button type="button">` for keyboard + a11y support

## Test plan
- [x] `npm run lint` — clean
- [x] `npm test` — 126/126 passing
- [ ] Manual: click a wallet card on `/:lang` (Landing donation section) and confirm clipboard contents + "Copied!" appears for 2s
- [ ] Manual: same on `/:lang/support`
- [ ] Manual: verify translations switch correctly between `/en/support` and `/zh/support`

Closes #30
Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)