### PR TITLE
chore(ci): add Claude Code Action for auto PR review

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,41 @@
+name: Claude Code Review
+
+# Triggers:
+#   - pull_request opened/synchronize/reopened  -> automatic first-pass review
+#   - issue_comment / pull_request_review_comment containing @claude -> on-demand answer
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  claude:
+    # Skip Dependabot PRs (dep bumps rarely benefit from LLM review and burn API budget).
+    # Skip fork PRs (GITHUB_TOKEN can't write to forks, so the action would run and silently fail).
+    # For comment events, skip ones authored by bots to avoid reply-loops with other integrations.
+    if: >-
+      !(github.event_name == 'pull_request' && (
+        github.event.pull_request.user.login == 'dependabot[bot]' ||
+        github.event.pull_request.head.repo.fork == true
+      )) &&
+      !(github.event.comment != null && endsWith(github.event.comment.user.login, '[bot]'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          trigger_phrase: '@claude'
+          # Pin to Opus 4.6; drop --max-turns lower if budget gets tight.
+          claude_args: --model claude-opus-4-6 --max-turns 5

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,8 +1,10 @@
 name: Claude Code Review
 
-# Triggers:
-#   - pull_request opened/synchronize/reopened  -> automatic first-pass review
-#   - issue_comment / pull_request_review_comment containing @claude -> on-demand answer
+# Triggers (the action itself filters comments via `trigger_phrase: '@claude'` below —
+# this workflow runs on every matching event and short-circuits inside the action if
+# the body doesn't contain the trigger phrase):
+#   - pull_request opened/synchronize/reopened -> automatic first-pass review
+#   - issue_comment / pull_request_review_comment (created) -> on-demand answer
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -11,31 +13,38 @@ on:
   pull_request_review_comment:
     types: [created]
 
+# Minimal permissions. Note: dropping `issues: write` means @claude on a pure issue
+# (not a PR) comment can be read but not replied to. Add it back if/when we want
+# Claude to answer standalone-issue threads.
 permissions:
   contents: read
   pull-requests: write
-  issues: write
 
 jobs:
   claude:
-    # Skip Dependabot PRs (dep bumps rarely benefit from LLM review and burn API budget).
-    # Skip fork PRs (GITHUB_TOKEN can't write to forks, so the action would run and silently fail).
-    # For comment events, skip ones authored by bots to avoid reply-loops with other integrations.
+    # Without these guards:
+    #   - Dependabot PRs would burn API budget on dep bumps that rarely need LLM review
+    #   - fork PRs would run but silently fail to post (GITHUB_TOKEN can't write to forks);
+    #     we invert the check to `fork != false` so an unknown/missing field defaults to
+    #     "treat as fork, skip" rather than running and failing silently
+    #   - bot-authored comments could create reply loops; we use `user.type == 'Bot'`
+    #     (GitHub's native flag) instead of a `[bot]` suffix check to also catch
+    #     bots with non-suffixed logins (codecov, snyk-bot, mergify, etc.)
     if: >-
       !(github.event_name == 'pull_request' && (
         github.event.pull_request.user.login == 'dependabot[bot]' ||
-        github.event.pull_request.head.repo.fork == true
+        github.event.pull_request.head.repo.fork != false
       )) &&
-      !(github.event.comment != null && endsWith(github.event.comment.user.login, '[bot]'))
+      !(github.event.comment != null && github.event.comment.user.type == 'Bot')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           trigger_phrase: '@claude'
-          # Pin to Opus 4.6; drop --max-turns lower if budget gets tight.
+          # Reduce --max-turns (currently 5) if API spend climbs.
           claude_args: --model claude-opus-4-6 --max-turns 5

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,11 +13,11 @@ on:
   pull_request_review_comment:
     types: [created]
 
-# Minimal permissions. Note: dropping `issues: write` means @claude on a pure issue
-# (not a PR) comment can be read but not replied to. Add it back if/when we want
-# Claude to answer standalone-issue threads.
+# Minimal permissions needed for OIDC auth plus PR/issue replies.
 permissions:
   contents: read
+  id-token: write
+  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Summary
Sets up **Plan A** from our review workflow decision: Anthropic's official Claude Code Action posts a first-pass review on every PR and replies whenever someone writes `@claude` in a PR/issue comment.

## Before merging
- [ ] Add \`ANTHROPIC_API_KEY\` under **Settings → Secrets and variables → Actions**. Without it the workflow will fail loudly on the first PR event (not silently).

## What's in the workflow
- Triggers: \`pull_request\` (opened/synchronize/reopened) + \`issue_comment\` + \`pull_request_review_comment\`
- Model pinned to \`claude-opus-4-6\` with \`--max-turns 5\` cap
- 15 min job timeout
- **Skipped on**: Dependabot PRs, fork PRs (can't write to forks), other bot comments (avoid reply loops)
- Permissions scoped: \`contents: read\`, \`pull-requests: write\`, \`issues: write\`

## Plan C companion (reminder)
Keep using \`/review-pr <num>\` (pr-review-toolkit) locally before merging for a deeper second pass — the GitHub Action is a first-pass triage, not a replacement.

## Test plan
- [ ] Add the secret
- [ ] Merge this PR
- [ ] Open a throwaway PR and verify Claude posts a review comment within ~1 min
- [ ] Comment \`@claude what does this diff do?\` on a PR and verify reply
- [ ] Verify Dependabot PRs do NOT trigger the action (check next dep bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)