### PR TITLE
fix(content): encode DeFi badge labels

### DIFF
--- a/zh/DeFiDeepDive/01_CoreConcepts/README.md
+++ b/zh/DeFiDeepDive/01_CoreConcepts/README.md
@@ -1,9 +1,9 @@
 # DeFi 核心概念与架构
 
-![status](https://img.shields.io/badge/ 状态 - 已完成 - success)
-![author](https://img.shields.io/badge/ 作者 - beihaili-blue)
-![date](https://img.shields.io/badge/ 日期 - 2025--06-orange)
-![difficulty](https://img.shields.io/badge/ 难度 - 中级 - yellow)
+![status](https://img.shields.io/badge/% E7%8A% B6% E6%80%81-% E5% B7% B2% E5% AE%8C% E6%88%90-success)
+![author](https://img.shields.io/badge/% E4% BD%9C% E8%80%85-beihaili-blue)
+![date](https://img.shields.io/badge/% E6%97% A5% E6%9C%9F-2025--06-orange)
+![difficulty](https://img.shields.io/badge/% E9%9A% BE% E5% BA% A6-% E4% B8% AD% E7% BA% A7-yellow)
 
 > 💡 本课将带你深入理解 DeFi（去中心化金融）的核心概念和架构设计。你将了解 DeFi 如何用智能合约重塑传统金融，以及为什么 "可组合性" 被称为 DeFi 最强大的超能力。
 >

--- a/zh/DeFiDeepDive/02_AMMAndDEX/README.md
+++ b/zh/DeFiDeepDive/02_AMMAndDEX/README.md
@@ -1,9 +1,9 @@
 # AMM 与去中心化交易所
 
-![status](https://img.shields.io/badge/ 状态 - 已完成 - success)
-![author](https://img.shields.io/badge/ 作者 - beihaili-blue)
-![date](https://img.shields.io/badge/ 日期 - 2025--06-orange)
-![difficulty](https://img.shields.io/badge/ 难度 - 中级 - yellow)
+![status](https://img.shields.io/badge/% E7%8A% B6% E6%80%81-% E5% B7% B2% E5% AE%8C% E6%88%90-success)
+![author](https://img.shields.io/badge/% E4% BD%9C% E8%80%85-beihaili-blue)
+![date](https://img.shields.io/badge/% E6%97% A5% E6%9C%9F-2025--06-orange)
+![difficulty](https://img.shields.io/badge/% E9%9A% BE% E5% BA% A6-% E4% B8% AD% E7% BA% A7-yellow)
 
 > 💡 本课将深入解析去中心化交易所（DEX）的核心机制 —— 自动做市商（AMM）。你将理解 Uniswap 的恒定乘积公式、流动性提供的完整流程，以及无常损失这个每个 LP 必须面对的概念。
 >

--- a/zh/DeFiDeepDive/03_LendingProtocols/README.md
+++ b/zh/DeFiDeepDive/03_LendingProtocols/README.md
@@ -1,9 +1,9 @@
 # 借贷协议原理
 
-![status](https://img.shields.io/badge/ 状态 - 已完成 - success)
-![author](https://img.shields.io/badge/ 作者 - beihaili-blue)
-![date](https://img.shields.io/badge/ 日期 - 2025--06-orange)
-![difficulty](https://img.shields.io/badge/ 难度 - 中级 - yellow)
+![status](https://img.shields.io/badge/% E7%8A% B6% E6%80%81-% E5% B7% B2% E5% AE%8C% E6%88%90-success)
+![author](https://img.shields.io/badge/% E4% BD%9C% E8%80%85-beihaili-blue)
+![date](https://img.shields.io/badge/% E6%97% A5% E6%9C%9F-2025--06-orange)
+![difficulty](https://img.shields.io/badge/% E9%9A% BE% E5% BA% A6-% E4% B8% AD% E7% BA% A7-yellow)
 
 > 💡 本课将带你理解 DeFi 借贷协议的工作原理。从 Aave 和 Compound 的核心机制，到超额抵押、清算和利率模型，再到 "闪电贷" 这个只有在区块链上才可能存在的魔法 —— 全面掌握 DeFi 借贷的知识体系。
 >

--- a/zh/DeFiDeepDive/04_Stablecoins/README.md
+++ b/zh/DeFiDeepDive/04_Stablecoins/README.md
@@ -1,9 +1,9 @@
 # 稳定币全景
 
-![status](https://img.shields.io/badge/ 状态 - 已完成 - success)
-![author](https://img.shields.io/badge/ 作者 - beihaili-blue)
-![date](https://img.shields.io/badge/ 日期 - 2025--06-orange)
-![difficulty](https://img.shields.io/badge/ 难度 - 中级 - yellow)
+![status](https://img.shields.io/badge/% E7%8A% B6% E6%80%81-% E5% B7% B2% E5% AE%8C% E6%88%90-success)
+![author](https://img.shields.io/badge/% E4% BD%9C% E8%80%85-beihaili-blue)
+![date](https://img.shields.io/badge/% E6%97% A5% E6%9C%9F-2025--06-orange)
+![difficulty](https://img.shields.io/badge/% E9%9A% BE% E5% BA% A6-% E4% B8% AD% E7% BA% A7-yellow)
 
 > 💡 稳定币是 DeFi 的基石和血液，其市值超过 1500 亿美元。本课将全面解析三种主要稳定币模式 —— 法币抵押、加密资产抵押和算法稳定币，并通过 UST/LUNA 崩盘案例揭示其中的风险。
 >

--- a/zh/DeFiDeepDive/05_DeFiRisks/README.md
+++ b/zh/DeFiDeepDive/05_DeFiRisks/README.md
@@ -1,9 +1,9 @@
 # DeFi 风险与安全
 
-![status](https://img.shields.io/badge/ 状态 - 已完成 - success)
-![author](https://img.shields.io/badge/ 作者 - beihaili-blue)
-![date](https://img.shields.io/badge/ 日期 - 2025--06-orange)
-![difficulty](https://img.shields.io/badge/ 难度 - 中级 - yellow)
+![status](https://img.shields.io/badge/% E7%8A% B6% E6%80%81-% E5% B7% B2% E5% AE%8C% E6%88%90-success)
+![author](https://img.shields.io/badge/% E4% BD%9C% E8%80%85-beihaili-blue)
+![date](https://img.shields.io/badge/% E6%97% A5% E6%9C%9F-2025--06-orange)
+![difficulty](https://img.shields.io/badge/% E9%9A% BE% E5% BA% A6-% E4% B8% AD% E7% BA% A7-yellow)
 
 > 💡 DeFi 给你前所未有的金融自由，同时也把安全责任完全交到了你手上。本课将系统性地梳理 DeFi 领域的主要风险类型，结合真实攻击案例，帮助你建立完整的风险认知框架和个人安全实践体系。
 >


### PR DESCRIPTION
## Summary
- URL-encode the Chinese label/value segments in DeFiDeepDive Shields.io badge URLs
- Keep the rendered badge text unchanged while preventing broken badge rendering

Closes #98

## Verification
- `rg "shields.io/badge/ " zh/DeFiDeepDive` returns no matches
- `git diff --check`
- Verified encoded Shields.io badge URL returns HTTP 200