### PR TITLE
Fix reading time edge cases and scroll utilities

### DIFF
--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,16 +1,31 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { ArrowUp } from 'lucide-react';
 
 /**
- * 回到顶部按钮，滚动超过 300px 后显示
+ * 回到顶部按钮，滚动超过一屏后显示
  */
 const ScrollToTop = () => {
   const [visible, setVisible] = useState(false);
+  const frameRef = useRef(null);
 
   useEffect(() => {
-    const onScroll = () => setVisible(window.scrollY > 300);
+    const updateVisibility = () => {
+      frameRef.current = null;
+      setVisible(window.scrollY > window.innerHeight);
+    };
+    const onScroll = () => {
+      if (frameRef.current !== null) return;
+      frameRef.current = window.requestAnimationFrame(updateVisibility);
+    };
+
+    updateVisibility();
     window.addEventListener('scroll', onScroll, { passive: true });
-    return () => window.removeEventListener('scroll', onScroll);
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      if (frameRef.current !== null) {
+        window.cancelAnimationFrame(frameRef.current);
+      }
+    };
   }, []);
 
   if (!visible) return null;
@@ -19,7 +34,7 @@ const ScrollToTop = () => {
     <button
       onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
       aria-label="Scroll to top"
-      className="fixed bottom-6 right-6 z-50 p-3 rounded-full bg-cyan-600 hover:bg-cyan-700 text-white shadow-lg transition-all"
+      className="fixed bottom-6 right-6 z-50 p-3 rounded-full bg-cyan-600 hover:bg-cyan-700 text-white shadow-lg transition-all focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-slate-950"
     >
       <ArrowUp className="w-5 h-5" />
     </button>

--- a/src/components/__tests__/ScrollToTop.test.jsx
+++ b/src/components/__tests__/ScrollToTop.test.jsx
@@ -1,0 +1,92 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ScrollToTop from '../ScrollToTop';
+
+const originalScrollYDescriptor = Object.getOwnPropertyDescriptor(window, 'scrollY');
+const originalInnerHeightDescriptor = Object.getOwnPropertyDescriptor(window, 'innerHeight');
+const originalScrollToDescriptor = Object.getOwnPropertyDescriptor(window, 'scrollTo');
+
+const setViewportScroll = ({ scrollY, innerHeight = 800 }) => {
+  Object.defineProperty(window, 'scrollY', {
+    configurable: true,
+    value: scrollY,
+  });
+  Object.defineProperty(window, 'innerHeight', {
+    configurable: true,
+    value: innerHeight,
+  });
+};
+
+describe('ScrollToTop', () => {
+  let rafCallback;
+
+  beforeEach(() => {
+    rafCallback = null;
+    setViewportScroll({ scrollY: 0 });
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      rafCallback = callback;
+      return 1;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalScrollYDescriptor) {
+      Object.defineProperty(window, 'scrollY', originalScrollYDescriptor);
+    } else {
+      delete window.scrollY;
+    }
+    if (originalInnerHeightDescriptor) {
+      Object.defineProperty(window, 'innerHeight', originalInnerHeightDescriptor);
+    } else {
+      delete window.innerHeight;
+    }
+    if (originalScrollToDescriptor) {
+      Object.defineProperty(window, 'scrollTo', originalScrollToDescriptor);
+    } else {
+      delete window.scrollTo;
+    }
+  });
+
+  it('should only appear after the user scrolls past one viewport', () => {
+    render(<ScrollToTop />);
+
+    expect(screen.queryByRole('button', { name: /scroll to top/i })).not.toBeInTheDocument();
+
+    act(() => {
+      setViewportScroll({ scrollY: 500, innerHeight: 800 });
+      window.dispatchEvent(new Event('scroll'));
+      rafCallback?.();
+    });
+
+    expect(screen.queryByRole('button', { name: /scroll to top/i })).not.toBeInTheDocument();
+
+    act(() => {
+      setViewportScroll({ scrollY: 801, innerHeight: 800 });
+      window.dispatchEvent(new Event('scroll'));
+      rafCallback?.();
+    });
+
+    expect(screen.getByRole('button', { name: /scroll to top/i })).toBeInTheDocument();
+  });
+
+  it('should scroll smoothly to the top when clicked', () => {
+    const scrollTo = vi.fn();
+    Object.defineProperty(window, 'scrollTo', {
+      configurable: true,
+      value: scrollTo,
+    });
+
+    render(<ScrollToTop />);
+
+    act(() => {
+      setViewportScroll({ scrollY: 900, innerHeight: 800 });
+      window.dispatchEvent(new Event('scroll'));
+      rafCallback?.();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /scroll to top/i }));
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+  });
+});

--- a/src/utils/__tests__/readingTime.test.js
+++ b/src/utils/__tests__/readingTime.test.js
@@ -21,4 +21,38 @@ describe('estimateReadingTime', () => {
     expect(estimateReadingTime('hello', 'en')).toBe(1);
     expect(estimateReadingTime('你好', 'zh')).toBe(1);
   });
+
+  it('should return 0 for blank markdown', () => {
+    // Blank input has no readable content, so it should behave like an empty string.
+    expect(estimateReadingTime('   \n\t  ', 'zh')).toBe(0);
+    expect(estimateReadingTime('   \n\t  ', 'en')).toBe(0);
+  });
+
+  it('should ignore fenced code blocks when estimating markdown reading time', () => {
+    const code = Array(800).fill('const value = expensiveComputation();').join('\n');
+    const markdown = ['Short intro paragraph.', '```js', code, '```'].join('\n');
+
+    expect(estimateReadingTime(markdown, 'en')).toBe(1);
+  });
+
+  it('should count Chinese characters and English words separately in mixed content', () => {
+    const chinese = '中'.repeat(400);
+    const english = Array(200).fill('word').join(' ');
+
+    expect(estimateReadingTime(`${chinese}\n\n${english}`, 'zh')).toBe(2);
+  });
+
+  it('should count markdown image alt text without counting the image URL', () => {
+    const longUrl = `https://example.com/${'path/'.repeat(300)}diagram.png`;
+    const markdown = `![区块链流程图](${longUrl})`;
+
+    expect(estimateReadingTime(markdown, 'zh')).toBe(1);
+  });
+
+  it('should ignore very long inline URLs', () => {
+    const longUrl = `https://example.com/${'very-long-segment/'.repeat(300)}`;
+    const markdown = `参考资料：${longUrl}`;
+
+    expect(estimateReadingTime(markdown, 'zh')).toBe(1);
+  });
 });

--- a/src/utils/__tests__/useClipboard.test.js
+++ b/src/utils/__tests__/useClipboard.test.js
@@ -1,0 +1,117 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useClipboard } from '../useClipboard';
+
+const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+const originalExecCommandDescriptor = Object.getOwnPropertyDescriptor(document, 'execCommand');
+
+const mockClipboard = (writeText) => {
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText },
+  });
+};
+
+describe('useClipboard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    if (originalClipboardDescriptor) {
+      Object.defineProperty(navigator, 'clipboard', originalClipboardDescriptor);
+    } else {
+      delete navigator.clipboard;
+    }
+    if (originalExecCommandDescriptor) {
+      Object.defineProperty(document, 'execCommand', originalExecCommandDescriptor);
+    } else {
+      delete document.execCommand;
+    }
+    document.body.innerHTML = '';
+  });
+
+  it('should copy with navigator.clipboard and clear copied after the reset delay', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    mockClipboard(writeText);
+
+    const { result } = renderHook(() => useClipboard());
+
+    await act(async () => {
+      await result.current.copy('wallet address');
+    });
+
+    expect(writeText).toHaveBeenCalledWith('wallet address');
+    expect(result.current.copied).toBe('wallet address');
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.copied).toBeNull();
+  });
+
+  it('should fall back to a hidden textarea when navigator.clipboard fails', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('Clipboard unavailable'));
+    const execCommand = vi.fn().mockReturnValue(true);
+    const appendChild = document.body.appendChild.bind(document.body);
+    let appendedTextarea;
+
+    mockClipboard(writeText);
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: execCommand,
+    });
+    vi.spyOn(document.body, 'appendChild').mockImplementation((node) => {
+      appendedTextarea = node;
+      return appendChild(node);
+    });
+
+    const { result } = renderHook(() => useClipboard());
+
+    await act(async () => {
+      await result.current.copy('fallback text');
+    });
+
+    expect(execCommand).toHaveBeenCalledWith('copy');
+    expect(appendedTextarea).toBeInstanceOf(HTMLTextAreaElement);
+    expect(appendedTextarea.value).toBe('fallback text');
+    expect(appendedTextarea.style.position).toBe('fixed');
+    expect(appendedTextarea.style.left).toBe('-9999px');
+    expect(document.body.contains(appendedTextarea)).toBe(false);
+    expect(result.current.copied).toBe('fallback text');
+  });
+
+  it('should keep the most recent copied value when copies happen before timeout', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    mockClipboard(writeText);
+
+    const { result } = renderHook(() => useClipboard());
+
+    await act(async () => {
+      await result.current.copy('a');
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    await act(async () => {
+      await result.current.copy('b');
+    });
+
+    expect(result.current.copied).toBe('b');
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(result.current.copied).toBe('b');
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(result.current.copied).toBeNull();
+  });
+});

--- a/src/utils/readingTime.js
+++ b/src/utils/readingTime.js
@@ -1,19 +1,50 @@
+const CJK_CHAR_RE = /[\u3400-\u9fff\uf900-\ufaff]/gu;
+const ENGLISH_WORD_RE = /[A-Za-z0-9]+(?:[-'][A-Za-z0-9]+)*/g;
+const FENCED_CODE_RE = /```[\s\S]*?```|~~~[\s\S]*?~~~/g;
+const IMAGE_RE = /!\[([^\]]*)\]\([^)]+\)/g;
+const LINK_RE = /\[([^\]]+)\]\([^)]+\)/g;
+const URL_RE = /\bhttps?:\/\/[^\s<>()]+/g;
+
+/**
+ * Removes markdown syntax that should not contribute to human reading time.
+ *
+ * Code fences and URLs are skipped because they can contain hundreds of tokens
+ * that users usually scan rather than read. Image alt text is preserved because
+ * it is the human-readable part of the image markdown.
+ *
+ * @param {string|null|undefined} text - Markdown or plain text content.
+ * @returns {string} Human-readable text used for reading-time estimation.
+ */
+function normalizeReadableText(text) {
+  if (typeof text !== 'string') return '';
+
+  return text
+    .replace(FENCED_CODE_RE, ' ')
+    .replace(IMAGE_RE, ' $1 ')
+    .replace(LINK_RE, ' $1 ')
+    .replace(URL_RE, ' ')
+    .replace(/`[^`\n]+`/g, ' ')
+    .trim();
+}
+
 /**
  * 估算阅读时间（中文按 400 字/分钟，英文按 200 词/分钟）
- * @param {string|null} text - 文本内容
- * @param {'zh'|'en'} lang - 语言，默认中文
- * @returns {number} 预计阅读分钟数（非空文本至少返回 1）
+ *
+ * Mixed Chinese/English content is counted by script: CJK characters count as
+ * Chinese reading units, and Latin words count as English reading units.
+ *
+ * @param {string|null|undefined} text - 文本内容
+ * @param {'zh'|'en'} _lang - 保留兼容的语言参数，计数会按脚本自动区分
+ * @returns {number} 预计阅读分钟数（有可读文本时至少返回 1）
  */
-export function estimateReadingTime(text, lang = 'zh') {
-  if (!text) return 0;
+export function estimateReadingTime(text, _lang = 'zh') {
+  const readableText = normalizeReadableText(text);
+  if (!readableText) return 0;
 
-  if (lang === 'zh') {
-    // 中文：去除空白后按字符数计算，400 字/分钟
-    const chars = text.replace(/\s/g, '').length;
-    return Math.max(1, Math.ceil(chars / 400));
-  }
+  const cjkChars = readableText.match(CJK_CHAR_RE)?.length ?? 0;
+  const textWithoutCjk = readableText.replace(CJK_CHAR_RE, ' ');
+  const englishWords = textWithoutCjk.match(ENGLISH_WORD_RE)?.length ?? 0;
+  const estimatedMinutes = cjkChars / 400 + englishWords / 200;
 
-  // 英文：按空格分词，200 词/分钟
-  const words = text.split(/\s+/).length;
-  return Math.max(1, Math.ceil(words / 200));
+  return estimatedMinutes > 0 ? Math.max(1, Math.ceil(estimatedMinutes)) : 0;
 }

--- a/src/utils/useClipboard.js
+++ b/src/utils/useClipboard.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 /**
  * Copies text to the clipboard and tracks which value was most recently copied.
@@ -11,6 +11,15 @@ import { useState } from 'react';
  */
 export function useClipboard(resetMs = 2000) {
   const [copied, setCopied] = useState(null);
+  const resetTimerRef = useRef(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current) {
+        clearTimeout(resetTimerRef.current);
+      }
+    };
+  }, []);
 
   const copy = async (text) => {
     try {
@@ -28,7 +37,14 @@ export function useClipboard(resetMs = 2000) {
       document.body.removeChild(textarea);
     }
     setCopied(text);
-    setTimeout(() => setCopied(null), resetMs);
+
+    if (resetTimerRef.current) {
+      clearTimeout(resetTimerRef.current);
+    }
+    resetTimerRef.current = setTimeout(() => {
+      setCopied((current) => (current === text ? null : current));
+      resetTimerRef.current = null;
+    }, resetMs);
   };
 
   return { copied, copy };


### PR DESCRIPTION
## Summary
- normalize markdown reading-time input so blank content, code fences, image URLs, bare URLs, and mixed Chinese/English text are counted correctly
- stabilize useClipboard reset timers and cover navigator.clipboard, fallback textarea, and rapid-copy paths
- update ScrollToTop to show after one viewport with requestAnimationFrame throttling and focus-ring coverage

## Verification
- npm run lint
- npm test (15 files, 136 tests)
- npm run build (prerender: 125 succeeded, 0 failed)

Closes #86
Closes #90
Closes #91