### PR TITLE
Add contributor growth system

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,83 +1,104 @@
-name: Bug 报告
-description: 提交一个 Bug 报告来帮助我们改进
-title: "[Bug] "
-labels: ["bug"]
+name: Bug Report / Bug 报告
+description: Report a product, content, build, or AI-native issue.
+title: '[Bug] '
+labels: ['bug']
 body:
   - type: markdown
     attributes:
       value: |
-        感谢你提交 Bug 报告！请尽可能详细地填写以下信息。
+        Thanks for helping improve Get Started with Web3. 请尽可能提供复现步骤、链接和截图。
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area / 问题区域
+      options:
+        - Website UI / 网站界面
+        - Lesson content / 课程内容
+        - Translation / 翻译
+        - Quiz or badges / 测验或徽章
+        - AI Tutor / AI 导师
+        - llms.txt or AI artifacts / AI 入口
+        - MCP server / MCP 服务
+        - Build or CI / 构建或 CI
+        - Other / 其他
+    validations:
+      required: true
 
   - type: textarea
     id: description
     attributes:
-      label: Bug 描述
-      description: 简要描述你遇到的问题
-      placeholder: 清晰描述 Bug 是什么
+      label: What happened? / 发生了什么？
+      placeholder: 'Describe the bug clearly.'
     validations:
       required: true
 
   - type: textarea
     id: steps
     attributes:
-      label: 复现步骤
-      description: 描述如何复现这个 Bug
+      label: Steps to reproduce / 复现步骤
       placeholder: |
-        1. 打开页面 '...'
-        2. 点击 '...'
-        3. 滚动到 '...'
-        4. 看到错误
+        1. Open ...
+        2. Click ...
+        3. See ...
     validations:
       required: true
 
   - type: textarea
     id: expected
     attributes:
-      label: 期望行为
-      description: 描述你期望发生的情况
+      label: Expected behavior / 期望行为
     validations:
       required: true
 
   - type: textarea
     id: actual
     attributes:
-      label: 实际行为
-      description: 描述实际发生的情况
+      label: Actual behavior / 实际行为
     validations:
       required: true
 
-  - type: textarea
-    id: screenshots
+  - type: input
+    id: url_or_file
     attributes:
-      label: 截图
-      description: 如果有的话，请添加截图来帮助说明问题
+      label: URL or file path / 链接或文件路径
+      placeholder: 'https://beihaili.github.io/Get-Started-with-Web3/... or en/...'
 
   - type: dropdown
     id: browser
     attributes:
-      label: 浏览器
+      label: Browser / 浏览器
       options:
         - Chrome
         - Firefox
         - Safari
         - Edge
-        - 其他
+        - Not browser-specific
+        - Other
     validations:
       required: true
 
   - type: dropdown
     id: device
     attributes:
-      label: 设备类型
+      label: Device / 设备
       options:
-        - 桌面端
-        - 移动端
-        - 平板
+        - Desktop
+        - Mobile
+        - Tablet
+        - Not device-specific
     validations:
       required: true
 
   - type: textarea
-    id: additional
+    id: screenshots
     attributes:
-      label: 补充信息
-      description: 其他可能有助于解决问题的信息
+      label: Screenshots or logs / 截图或日志
+      description: Paste screenshots, console output, or CI log links when useful.
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution / 贡献意向
+      options:
+        - label: I can help fix this bug.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Live learning site
+    url: https://beihaili.github.io/Get-Started-with-Web3/
+    about: Read the public curriculum before opening a content issue.
+  - name: Contributor guide
+    url: https://github.com/beihaili/Get-Started-with-Web3/blob/main/CONTRIBUTING.en.md
+    about: Learn how to make a first contribution.
+  - name: Good first issues catalog
+    url: https://github.com/beihaili/Get-Started-with-Web3/blob/main/docs/community/good-first-issues.md
+    about: Copy-ready starter issue ideas for contributors.

--- a/.github/ISSUE_TEMPLATE/content_contribution.yml
+++ b/.github/ISSUE_TEMPLATE/content_contribution.yml
@@ -1,0 +1,78 @@
+name: Content or Translation Contribution
+description: Improve a lesson, translation, quiz, glossary term, or source citation.
+title: '[Content] '
+labels: ['content']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for improving the Web3 curriculum. 请说明你要改进的内容、语言和学习目标。
+
+  - type: dropdown
+    id: language
+    attributes:
+      label: Language / 语言
+      options:
+        - Chinese / 中文
+        - English / 英文
+        - Bilingual / 双语
+        - Not language-specific / 非语言相关
+    validations:
+      required: true
+
+  - type: input
+    id: module
+    attributes:
+      label: Module or file path / 模块或文件路径
+      placeholder: 'en/DeFiDeepDive/01_CoreConcepts/README.md'
+    validations:
+      required: true
+
+  - type: dropdown
+    id: contribution_type
+    attributes:
+      label: Contribution type / 贡献类型
+      options:
+        - Fix unclear or outdated lesson content
+        - Add source links or further reading
+        - Translate missing content
+        - Proofread existing translation
+        - Add quiz questions
+        - Add glossary terms
+        - Improve AI-native citations or context
+        - Other content improvement
+    validations:
+      required: true
+
+  - type: textarea
+    id: learner_outcome
+    attributes:
+      label: Learner outcome / 学习者收益
+      description: What should a beginner understand or do better after this change?
+      placeholder: 'After this change, learners can...'
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_change
+    attributes:
+      label: Proposed change / 计划修改
+      description: Describe the exact content change you want to make.
+    validations:
+      required: true
+
+  - type: textarea
+    id: sources
+    attributes:
+      label: Sources / 参考来源
+      description: Add official docs, reputable explainers, specs, or notes. Leave blank for typo-only changes.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Expected checks / 预期验证
+      options:
+        - label: Markdown preview or local app review is enough.
+        - label: This may need `npm run ai:index && npm run ai:publish && npm run ai:verify`.
+        - label: This may need `npm test`.
+        - label: I can help implement this change.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,52 +1,74 @@
-name: 功能请求
-description: 提出一个新功能或改进建议
-title: "[Feature] "
-labels: ["enhancement"]
+name: Feature Request / 功能请求
+description: Suggest a product, learning, AI-native, or curriculum improvement.
+title: '[Feature] '
+labels: ['enhancement']
 body:
   - type: markdown
     attributes:
       value: |
-        感谢你的建议！请描述你希望添加的功能。
+        Please describe the learner or contributor problem first. 请先描述真实问题，再描述方案。
 
   - type: textarea
     id: problem
     attributes:
-      label: 问题描述
-      description: 这个功能请求是否与某个问题有关？请描述。
-      placeholder: 当我 ... 的时候，我觉得很不方便因为 ...
+      label: Problem / 问题
+      description: What is hard, missing, confusing, or inefficient today?
+      placeholder: 'When I try to..., I cannot...'
+    validations:
+      required: true
+
+  - type: textarea
+    id: audience
+    attributes:
+      label: Audience / 受众
+      description: Who benefits from this feature?
+      placeholder: 'Beginner learner, Web3 builder, contributor, AI agent, sponsor...'
     validations:
       required: true
 
   - type: textarea
     id: solution
     attributes:
-      label: 期望的解决方案
-      description: 描述你希望如何解决这个问题
+      label: Proposed solution / 期望方案
+      description: Describe the smallest useful version.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category / 类别
+      options:
+        - Lesson content
+        - Learning workflow
+        - AI Tutor
+        - AI-native artifacts or MCP
+        - Search or navigation
+        - Quiz or badges
+        - Accessibility
+        - Performance
+        - SEO or growth
+        - Other
     validations:
       required: true
 
   - type: textarea
     id: alternatives
     attributes:
-      label: 替代方案
-      description: 描述你考虑过的其他替代方案
-
-  - type: dropdown
-    id: category
-    attributes:
-      label: 功能类别
-      options:
-        - 教程内容
-        - 用户界面
-        - 学习功能
-        - 性能优化
-        - 无障碍
-        - 其他
-    validations:
-      required: true
+      label: Alternatives / 替代方案
+      description: Other approaches you considered.
 
   - type: textarea
-    id: additional
+    id: success
     attributes:
-      label: 补充信息
-      description: 其他可能有助于理解需求的信息（截图、链接等）
+      label: Success metric / 成功标准
+      description: What would prove this helped?
+      placeholder: 'More completed lessons, fewer confused comments, better AI citations...'
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution / 贡献意向
+      options:
+        - label: I can help design this.
+        - label: I can help implement this.

--- a/.github/ISSUE_TEMPLATE/growth_distribution.yml
+++ b/.github/ISSUE_TEMPLATE/growth_distribution.yml
@@ -1,0 +1,68 @@
+name: Growth, Community, or Distribution
+description: Suggest a distribution channel, community post, awesome-list submission, partnership, or sponsor lead.
+title: '[Growth] '
+labels: ['growth']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for growth work that can help the project reach more learners or contributors. 请避免投资建议、代币推广和未披露广告。
+
+  - type: dropdown
+    id: growth_type
+    attributes:
+      label: Growth type / 增长类型
+      options:
+        - Awesome-list submission
+        - Community post
+        - Newsletter or media pitch
+        - Workshop or study group
+        - Partnership lead
+        - Sponsor lead
+        - SEO or discoverability
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: audience
+    attributes:
+      label: Target audience / 目标受众
+      placeholder: 'English-speaking Web3 beginners, Chinese builders, AI agents, protocol educators...'
+    validations:
+      required: true
+
+  - type: input
+    id: channel
+    attributes:
+      label: Channel or URL / 渠道或链接
+      placeholder: 'https://github.com/...'
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_copy
+    attributes:
+      label: Proposed copy or action / 文案或动作
+      description: Include draft copy, submission notes, or the exact action you recommend.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_result
+    attributes:
+      label: Expected result / 预期结果
+      description: What would count as success?
+      placeholder: 'A merged awesome-list PR, 10 qualified visitors, one contributor lead...'
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: policy
+    attributes:
+      label: Policy check / 边界检查
+      options:
+        - label: This does not require changing wallet addresses, repository ownership, secrets, or payment terms.
+          required: true
+        - label: This does not make investment advice, trading claims, or token promotion.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,34 +1,52 @@
-## 变更描述
+## Summary / 变更摘要
 
-<!-- 简要描述这个 PR 做了什么 -->
+<!-- What changed? 哪些内容发生了变化？ -->
 
-## 变更类型
+## Type / 类型
 
-- [ ] Bug 修复
-- [ ] 新功能
-- [ ] 文档改进
-- [ ] 代码重构
-- [ ] 测试
-- [ ] 其他
+- [ ] Bug fix / Bug 修复
+- [ ] Feature / 新功能
+- [ ] Lesson content / 课程内容
+- [ ] Translation or proofreading / 翻译或校对
+- [ ] Quiz or glossary / 测验或术语表
+- [ ] AI-native artifacts or MCP / AI 入口或 MCP
+- [ ] Growth, community, or sponsorship docs / 增长、社区或赞助文档
+- [ ] Refactor or tooling / 重构或工具
 
-## 相关 Issue
+## Scope / 影响范围
 
-<!-- 如果有相关 Issue，请链接 -->
+<!-- List affected files, lessons, routes, modules, or audiences. 写清楚影响的文件、课程、页面、模块或受众。 -->
+
+## Related Issue / 相关 Issue
+
+<!-- Example: Closes #123. If no issue exists, explain why. -->
+
 Closes #
 
-## 测试
+## Verification / 验证
 
-- [ ] 本地测试通过 (`npm test`)
-- [ ] Lint 检查通过 (`npm run lint`)
-- [ ] 构建成功 (`npm run build`)
+- [ ] Markdown preview or docs-only review
+- [ ] `npx prettier --check <changed-files>`
+- [ ] `npm test`
+- [ ] `npm run lint`
+- [ ] `npm run build`
+- [ ] `npm run ai:index`
+- [ ] `npm run ai:publish`
+- [ ] `npm run ai:verify`
+- [ ] Not applicable; reason:
 
-## 截图（如适用）
+## Content And Safety / 内容与安全
 
-<!-- 如果有 UI 变更，请添加截图 -->
+- [ ] Beginner-facing wording is clear.
+- [ ] Technical claims include sources or are already covered by existing course context.
+- [ ] No investment advice, yield promises, token promotion, or undisclosed ads.
+- [ ] Chinese and English terminology stays aligned when both languages are affected.
+- [ ] AI-native changes keep MCP tools read-only and citeable.
 
-## 检查清单
+## Screenshots / 截图
 
-- [ ] 代码遵循项目的代码风格
-- [ ] 已添加必要的测试
-- [ ] 所有现有测试通过
-- [ ] 已更新相关文档
+<!-- Add screenshots for UI changes. UI 修改请提供截图。 -->
+
+## Notes For Reviewers / Reviewer 备注
+
+<!-- Anything reviewers should pay special attention to? -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,14 @@
 - `docs/strategy/2026-05-14-sponsor-kit.md`: 赞助包草案，包含受众、价格、曝光权益、接受政策和月度汇报指标。
 - `docs/strategy/2026-05-14-sponsor-outreach-drafts.md`: 赞助外联话术草案；常规外联可自主执行，高风险赞助对象仍需单独确认。
 - `docs/strategy/2026-05-14-awesome-list-submissions.md`: awesome-list 和社区分发追踪，包含定位文案、目标列表、PR 模板和中文社区帖草案。
+- `docs/community/contributor-ladder.md`: 贡献者成长路径，定义 first-time contributor、repeat contributor、reviewer、module steward 和 community/sponsor ally。
+- `docs/community/good-first-issues.md`: 可复制到 GitHub Issues 的 starter issue 清单，包含标签、背景、验收标准和验证方式。
+
+社区入口：
+
+- `CONTRIBUTING.md` / `CONTRIBUTING.en.md`: 双语贡献指南，维护贡献路径、验证矩阵和内容质量标准。
+- `.github/ISSUE_TEMPLATE/`: Bug、feature、content/translation、growth/community 分流模板。
+- `.github/PULL_REQUEST_TEMPLATE.md`: PR 验证和内容安全检查清单。
 
 工作边界：
 

--- a/CONTRIBUTING.en.md
+++ b/CONTRIBUTING.en.md
@@ -3,136 +3,111 @@
 
 # Contributing Guide
 
-## Your First Contribution in 5 Minutes
+Thank you for contributing to **Get Started with Web3**. The project is becoming an open-source, bilingual, AI-native Web3 learning platform. Contributions include code, lesson content, translation, proofreading, quizzes, glossary entries, community distribution, and sponsor research.
 
-1. **Fork** this repository
-2. **Find an issue** labeled `good first issue` in [Issues](https://github.com/beihaili/Get-Started-with-Web3/issues)
-3. **Clone** your fork: `git clone https://github.com/YOUR_USERNAME/Get-Started-with-Web3.git`
-4. **Create a branch**: `git checkout -b fix/your-change`
-5. **Make your change** (fix a typo, improve a translation, add a quiz question)
-6. **Commit**: `git commit -m "fix: describe your change"`
-7. **Push and open a PR**: `git push origin fix/your-change`
-
-Not sure where to start? Translation proofreading is the easiest way to contribute — just find a file in `en/` and improve the English!
-
-Thank you for your interest in the **Get Started with Web3** project! We welcome all forms of contributions.
-
-## How to Participate
-
-### Reporting Issues
-
-If you find a bug or have a suggestion for improvement, please submit it in [GitHub Issues](https://github.com/beihaili/Get-Started-with-Web3/issues):
-
-1. Search for existing issues to avoid duplicates.
-2. Use the appropriate issue template (Bug Report / Feature Request).
-3. Provide as much detail as possible, including reproduction steps and screenshots.
-
-### Submitting Code
+## Your First Contribution In 5 Minutes
 
 1. Fork this repository.
-2. Create a feature branch: `git checkout -b feat/your-feature`.
-3. Commit your changes (follow the commit convention).
-4. Push to your fork: `git push origin feat/your-feature`.
-5. Create a Pull Request.
+2. Pick a task from the [Good First Issues Catalog](docs/community/good-first-issues.md), or browse open [`good first issue`](https://github.com/beihaili/Get-Started-with-Web3/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) tickets.
+3. Clone your fork: `git clone https://github.com/YOUR_USERNAME/Get-Started-with-Web3.git`
+4. Create a branch: `git checkout -b fix/your-change`
+5. Make a small, focused change.
+6. Run the matching verification command.
+7. Push and open a Pull Request.
 
-### Improving Documentation
+If you are unsure where to start, proofread an English lesson, check links, add glossary terms, add quiz questions, or improve a security warning. These are easy to review and directly improve the learner experience.
 
-- Correct errors or outdated information in tutorials.
-- Supplement code examples and explanations.
-- Improve the clarity and accuracy of the writing.
+## Contribution Tracks
 
-### Translation
+| Track            | Good work                                                     | Start here                                                    |
+| ---------------- | ------------------------------------------------------------- | ------------------------------------------------------------- |
+| Lesson content   | Fix stale facts, add sources, add examples, improve warnings  | Lesson README files under `zh/` and `en/`                     |
+| Translation      | Translate, proofread, align terminology, improve English flow | `en/Web3QuickStart/`, `en/DeFiDeepDive/`                      |
+| Quiz / Glossary  | Add questions, terms, module checks, beginner explanations    | `src/features/quiz/quizData.js`, `src/config/glossaryData.js` |
+| Product quality  | Fix UI, accessibility, mobile, search, or AI Tutor behavior   | Components and tests under `src/`                             |
+| AI-native layer  | Improve `llms.txt`, manifest, MCP, and citation quality       | `ai/`, `public/ai/`, `scripts/`                               |
+| Growth/community | Submit to awesome lists, draft posts, research sponsors       | `docs/strategy/`, `docs/community/`                           |
 
-- We are currently translating from Chinese to English (`en/` directory).
-- Feel free to translate existing tutorials or proofread existing translations.
+For the long-term path, see the [Contributor Ladder](docs/community/contributor-ladder.md).
 
-## Development Environment Setup
+## Development Setup
 
 ```bash
-# Clone the repository
 git clone https://github.com/beihaili/Get-Started-with-Web3.git
 cd Get-Started-with-Web3
-
-# Install dependencies
 npm install
-
-# Start the development server
 npm run dev
-
-# Run tests
-npm test
-
-# Run lint check
-npm run lint
 ```
 
-## Branching and Commit Conventions
+Common commands:
 
-### Branch Naming
-
-- `feat/xxx` — New feature
-- `fix/xxx` — Bug fix
-- `docs/xxx` — Documentation improvement
-- `refactor/xxx` — Code refactoring
-
-### Commit Message
-
-We use the [Conventional Commits](https://www.conventionalcommits.org/) convention:
-
+```bash
+npm test          # Vitest suite
+npm run lint      # ESLint
+npm run build     # production build, OG images, sitemap, prerender
+npm run ai:verify # verify public AI entrypoints and x402 metadata
 ```
+
+## Verification Matrix
+
+| Change type                | Run at minimum                                                |
+| -------------------------- | ------------------------------------------------------------- |
+| Markdown-only docs         | `npx prettier --check <changed-files>`                        |
+| New or moved lessons       | `npm run ai:index && npm run ai:publish && npm run ai:verify` |
+| Glossary changes           | `npm test -- src/config/__tests__/glossaryData.test.js`       |
+| Quiz or course config      | `npm test`                                                    |
+| React/UI/script changes    | `npm test && npm run lint`                                    |
+| SEO, sitemap, or prerender | `npm test && npm run build`                                   |
+| AI-native or MCP layer     | `npm test && npm run ai:verify`                               |
+
+If you cannot run a command, explain why in the PR and list what you did verify.
+
+## Content Quality Bar
+
+- Write for beginners. Do not assume the reader already understands wallets, gas, signatures, bridges, or DeFi risk.
+- Cite credible sources for protocol mechanics, security behavior, chain operations, or market structure.
+- Do not include investment advice, yield promises, token promotion, or undisclosed promotional copy.
+- Keep Chinese and English terminology aligned. Note your choice in the PR when a term is ambiguous.
+- Use relative paths and alt text when adding images or diagrams.
+
+## Branches And Commits
+
+Branch names:
+
+- `feat/xxx`: new feature
+- `fix/xxx`: bug fix
+- `docs/xxx`: documentation improvement
+- `content/xxx`: lesson content improvement
+
+Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```text
 <type>: <description>
-
-[optional body]
 ```
 
-Common types:
-- `feat` — New feature
-- `fix` — Bug fix
-- `docs` — Documentation change
-- `style` — Code style (no functional impact)
-- `refactor` — Refactoring
-- `test` — Testing
-- `chore` — Build/tooling changes
+Examples:
 
-Example:
-```
-feat: add quiz for Bitcoin Script lesson
-fix: correct image path in SegWit tutorial
-docs: update README with new learning path
+```text
+docs: improve DeFi risk explanation
+fix: correct SegWit image path
+feat: add smart account glossary terms
 ```
 
-## Code Style
+## Pull Request Process
 
-- Use ESLint + Prettier to maintain code consistency.
-- A `lint-staged` check will automatically run before each commit.
-- Manual formatting: `npm run format`
+1. Keep the PR small and focused.
+2. Mention the affected language, module, lesson, or page.
+3. Check the validation commands you actually ran.
+4. Add screenshots for UI changes and source links for content changes.
+5. Respond to review feedback.
+6. After merge, pick another starter issue if you want to continue.
 
-## PR Process
+## Maintainer Response
 
-1. Ensure the code passes all tests: `npm test`.
-2. Ensure there are no linting errors: `npm run lint`.
-3. Fill in all necessary information in the PR template.
-4. Wait for Code Review.
-5. Make changes based on feedback.
-6. Delete the feature branch after merging.
+When maintainers are active, the target is to give starter PRs an initial response within 72 hours. Larger content or product changes may need more discussion; open an issue first when scope is unclear.
 
-## Tutorial Content Guidelines
+## Contact
 
-When writing or modifying tutorials:
-
-- Use Markdown format.
-- Place each lesson in an independent numbered directory (e.g., `01_FirstWeb3Identity/`).
-- Name the main file `README.MD`.
-- Place code examples in the `code_examples/` subdirectory.
-- Use relative paths for images.
-- Place Chinese content in the `zh/` directory and English content in the `en/` directory.
-
-## Contact Us
-
-- Twitter: [@bhbtc1337](https://twitter.com/bhbtc1337)
+- Twitter/X: [@bhbtc1337](https://twitter.com/bhbtc1337)
 - GitHub Issues: [Submit an issue](https://github.com/beihaili/Get-Started-with-Web3/issues)
-- WeChat Group: Apply via Google Form.
-
-## Acknowledgments
-
-Thanks to every contributor! Your participation makes Web3 education better.
+- WeChat group: Apply through the Google Form.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,136 +3,111 @@
 
 # 贡献指南
 
-## Your First Contribution in 5 Minutes
+感谢你参与 **Get Started with Web3**。这个项目的目标是做成开源、双语、AI-native 的 Web3 学习平台。贡献不只包括写代码，也包括翻译、校对、课程资料、测验、术语表、社区传播和赞助线索。
 
-1. **Fork** this repository
-2. **Find an issue** labeled `good first issue` in [Issues](https://github.com/beihaili/Get-Started-with-Web3/issues)
-3. **Clone** your fork: `git clone https://github.com/YOUR_USERNAME/Get-Started-with-Web3.git`
-4. **Create a branch**: `git checkout -b fix/your-change`
-5. **Make your change** (fix a typo, improve a translation, add a quiz question)
-6. **Commit**: `git commit -m "fix: describe your change"`
-7. **Push and open a PR**: `git push origin fix/your-change`
+## 5 分钟完成第一次贡献
 
-Not sure where to start? Translation proofreading is the easiest way to contribute — just find a file in `en/` and improve the English!
+1. Fork 本仓库。
+2. 从 [Good First Issues Catalog](docs/community/good-first-issues.md) 选一个任务，或查看 GitHub 上的 [`good first issue`](https://github.com/beihaili/Get-Started-with-Web3/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)。
+3. 克隆你的 fork：`git clone https://github.com/YOUR_USERNAME/Get-Started-with-Web3.git`
+4. 创建分支：`git checkout -b fix/your-change`
+5. 提交小而清晰的修改。
+6. 本地运行对应验证命令。
+7. Push 并打开 Pull Request。
 
-感谢你对 **Get Started with Web3** 项目的关注！我们欢迎所有形式的贡献。
+不知道从哪里开始时，优先做英文校对、链接检查、术语补充、测验题或安全提示改进。这些任务最容易 review，也最能直接提升学习体验。
 
-## 如何参与
+## 贡献路径
 
-### 报告问题
+| 路径            | 适合做什么                                    | 推荐起点                                                      |
+| --------------- | --------------------------------------------- | ------------------------------------------------------------- |
+| 课程内容        | 修正过时信息、补来源、增加示例、改安全提示    | `zh/`、`en/` 下的 lesson README                               |
+| 翻译与校对      | 中英文互译、术语统一、改善英文表达            | `en/Web3QuickStart/`、`en/DeFiDeepDive/`                      |
+| Quiz / Glossary | 添加测验题、术语解释、模块练习                | `src/features/quiz/quizData.js`、`src/config/glossaryData.js` |
+| 产品体验        | 修 UI、可访问性、移动端、搜索、AI Tutor 体验  | `src/` 下对应组件和测试                                       |
+| AI-native       | 改进 `llms.txt`、AI manifest、MCP 和引用质量  | `ai/`、`public/ai/`、`scripts/`                               |
+| 增长与社区      | awesome-list 投稿、社区帖、赞助研究、案例传播 | `docs/strategy/`、`docs/community/`                           |
 
-如果你发现了 Bug 或有改进建议，请在 [GitHub Issues](https://github.com/beihaili/Get-Started-with-Web3/issues) 中提交：
+更多长期协作方式见 [Contributor Ladder](docs/community/contributor-ladder.md)。
 
-1. 搜索现有 Issue，避免重复提交
-2. 使用对应的 Issue 模板（Bug 报告 / 功能请求）
-3. 尽可能提供详细的复现步骤和截图
-
-### 提交代码
-
-1. Fork 本仓库
-2. 创建功能分支：`git checkout -b feat/your-feature`
-3. 提交更改（遵循提交规范）
-4. 推送到你的 Fork：`git push origin feat/your-feature`
-5. 创建 Pull Request
-
-### 改进文档
-
-- 修正教程中的错误或过时信息
-- 补充代码示例和说明
-- 改善行文的清晰度和准确性
-
-### 翻译
-
-- 我们正在从中文翻译到英文（`en/` 目录）
-- 欢迎翻译现有教程或校对已有翻译
-
-## 开发环境搭建
+## 开发环境
 
 ```bash
-# 克隆仓库
 git clone https://github.com/beihaili/Get-Started-with-Web3.git
 cd Get-Started-with-Web3
-
-# 安装依赖
 npm install
-
-# 启动开发服务器
 npm run dev
-
-# 运行测试
-npm test
-
-# 运行 lint 检查
-npm run lint
 ```
+
+常用命令：
+
+```bash
+npm test          # 全量 Vitest
+npm run lint      # ESLint
+npm run build     # 生产构建、OG、sitemap、prerender
+npm run ai:verify # 验证公开 AI entrypoints 和 x402 元数据
+```
+
+## 验证矩阵
+
+| 修改类型                  | 至少运行                                                      |
+| ------------------------- | ------------------------------------------------------------- |
+| 只改 Markdown 文档        | `npx prettier --check <changed-files>`                        |
+| 新增或移动课程            | `npm run ai:index && npm run ai:publish && npm run ai:verify` |
+| 修改术语表                | `npm test -- src/config/__tests__/glossaryData.test.js`       |
+| 修改 quiz 或课程配置      | `npm test`                                                    |
+| 修改 React/UI/脚本        | `npm test && npm run lint`                                    |
+| 修改 SEO、sitemap、预渲染 | `npm test && npm run build`                                   |
+| 修改 AI-native/MCP 层     | `npm test && npm run ai:verify`                               |
+
+如果你无法运行某个命令，请在 PR 中说明原因和你已经完成的检查。
+
+## 内容质量要求
+
+- 面向初学者解释，不假设读者已经懂钱包、Gas、签名、桥或 DeFi 风险。
+- 涉及协议机制、安全风险、链上操作或市场结构时，尽量引用可信来源。
+- 不写投资建议、收益承诺、代币喊单或无披露的推广内容。
+- 中英文术语保持一致；不确定时在 PR 中说明你的选择。
+- 新增图片或图表时使用相对路径，并提供 alt text。
 
 ## 分支与提交规范
 
-### 分支命名
+分支命名：
 
-- `feat/xxx` — 新功能
-- `fix/xxx` — Bug 修复
-- `docs/xxx` — 文档改进
-- `refactor/xxx` — 代码重构
+- `feat/xxx`：新功能
+- `fix/xxx`：Bug 修复
+- `docs/xxx`：文档改进
+- `content/xxx`：课程内容改进
 
-### 提交信息
+提交信息遵循 [Conventional Commits](https://www.conventionalcommits.org/)：
 
-我们使用 [Conventional Commits](https://www.conventionalcommits.org/) 规范：
-
-```
+```text
 <type>: <description>
-
-[optional body]
 ```
-
-常用 type：
-- `feat` — 新功能
-- `fix` — Bug 修复
-- `docs` — 文档变更
-- `style` — 代码样式（不影响功能）
-- `refactor` — 重构
-- `test` — 测试
-- `chore` — 构建/工具变更
 
 示例：
-```
-feat: add quiz for Bitcoin Script lesson
-fix: correct image path in SegWit tutorial
-docs: update README with new learning path
-```
 
-## 代码风格
-
-- 使用 ESLint + Prettier 保持代码一致性
-- 提交前会自动运行 lint-staged 检查
-- 手动格式化：`npm run format`
+```text
+docs: improve DeFi risk explanation
+fix: correct SegWit image path
+feat: add smart account glossary terms
+```
 
 ## PR 流程
 
-1. 确保代码通过所有测试：`npm test`
-2. 确保没有 lint 错误：`npm run lint`
-3. 填写 PR 模板中的所有必要信息
-4. 等待 Code Review
-5. 根据反馈进行修改
-6. 合并后删除功能分支
+1. 保持 PR 小而聚焦。
+2. 在 PR 描述里写清楚影响的语言、模块、lesson 或页面。
+3. 勾选实际运行过的验证命令。
+4. UI 修改提供截图；内容修改提供来源或说明。
+5. 根据 review 反馈修改。
+6. 合并后可继续挑选下一条 starter issue。
 
-## 教程内容规范
+## 维护者响应
 
-编写或修改教程时：
+Starter PR 在维护者活跃时目标是 72 小时内给出初次响应。大型内容或产品改动可能需要更多上下文，请先开 issue 讨论范围。
 
-- 使用 Markdown 格式
-- 每课放在独立的编号目录中（如 `01_FirstWeb3Identity/`）
-- 主文件命名为 `README.MD`
-- 代码示例放在 `code_examples/` 子目录
-- 图片使用相对路径引用
-- 中文内容放在 `zh/` 目录，英文放在 `en/` 目录
+## 联系
 
-## 联系我们
-
-- Twitter: [@bhbtc1337](https://twitter.com/bhbtc1337)
+- Twitter/X: [@bhbtc1337](https://twitter.com/bhbtc1337)
 - GitHub Issues: [提交问题](https://github.com/beihaili/Get-Started-with-Web3/issues)
-- 微信群：通过 Google Form 申请加入
-
-## 致谢
-
-感谢每一位贡献者！你的参与让 Web3 教育变得更好。
+- WeChat group: 通过 Google Form 申请加入

--- a/README.md
+++ b/README.md
@@ -157,7 +157,9 @@ Good first contributions:
 
 Start here:
 
-- [Contributing guide](CONTRIBUTING.md)
+- [Contributing guide](CONTRIBUTING.en.md)
+- [Contributor ladder](docs/community/contributor-ladder.md)
+- [Good first issues catalog](docs/community/good-first-issues.md)
 - [Open good first issues](https://github.com/beihaili/Get-Started-with-Web3/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 - [All issues](https://github.com/beihaili/Get-Started-with-Web3/issues)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -158,6 +158,8 @@ npm run mcp:web3
 入口：
 
 - [贡献指南](CONTRIBUTING.md)
+- [贡献者成长路径](docs/community/contributor-ladder.md)
+- [Good first issues 清单](docs/community/good-first-issues.md)
 - [good first issues](https://github.com/beihaili/Get-Started-with-Web3/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 - [所有 issues](https://github.com/beihaili/Get-Started-with-Web3/issues)
 

--- a/docs/community/contributor-ladder.md
+++ b/docs/community/contributor-ladder.md
@@ -1,0 +1,59 @@
+# Contributor Ladder
+
+> 中文说明：这份文档定义项目如何把一次性贡献者转化为长期协作者、模块维护者和社区传播节点。
+
+Get Started with Web3 grows when learners become contributors. The ladder below makes that path explicit so a newcomer knows what to do next and maintainers know how to recognize progress.
+
+## Principles
+
+- Keep the curriculum free and beginner-friendly.
+- Prefer small, reviewable pull requests over large rewrites.
+- Cite credible sources when a lesson claims a protocol fact, security behavior, or market mechanism.
+- Treat bilingual quality as product quality, not a secondary task.
+- Turn useful discussions into reusable docs, issues, or lesson updates.
+
+## Roles
+
+| Role                      | How to qualify                                                                  | Typical work                                                                | Recognition                                             |
+| ------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------- |
+| First-time contributor    | Open one merged typo, translation, quiz, glossary, or small docs PR             | Fix unclear wording, broken links, minor translation gaps, small examples   | Thanks in PR, encouraged to pick another starter issue  |
+| Repeat contributor        | Land three useful PRs in any track                                              | Improve a full lesson, add quiz coverage, update examples, review sources   | Mention in monthly update and eligible for issue triage |
+| Reviewer                  | Give two helpful reviews or reproduce two issues                                | Review lesson clarity, test steps, screenshots, accessibility, AI artifacts | Added to reviewer rotation in public roadmap notes      |
+| Module steward            | Maintain one topic area across multiple PRs                                     | Own freshness for a module, propose lesson sequence, curate sources         | Listed in community updates and module ownership notes  |
+| Community or sponsor ally | Bring distribution, translations, workshops, sponsorship leads, or partnerships | Share the project, coordinate community review, route sponsor opportunities | Mentioned in growth reports when appropriate            |
+
+## Contribution Tracks
+
+| Track             | Good first task                                             | Strong contribution                                | Verification                               |
+| ----------------- | ----------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------ |
+| Content clarity   | Fix a confusing paragraph or outdated link                  | Rewrite a lesson section with sources and examples | Markdown preview, source links checked     |
+| Translation       | Proofread one `en/` or `zh/` lesson                         | Translate a missing lesson and align terminology   | `npm run ai:index` when lesson set changes |
+| Quiz and glossary | Add one quiz question or glossary term                      | Add a mini assessment for a full module            | Relevant Vitest or content checks          |
+| Product quality   | Fix a UI bug, accessibility issue, or mobile layout problem | Improve a learning workflow with tests             | `npm test`, `npm run lint`, screenshots    |
+| AI-native layer   | Improve `llms.txt`, manifest copy, or content citations     | Add a new read-only MCP capability with tests      | `npm run ai:verify`                        |
+| Growth            | Submit to an awesome list or write a community post         | Run a distribution loop and report results         | Link to post, issue, PR, or metrics        |
+
+## Review Rhythm
+
+- Starter PRs should get an initial response within 72 hours when maintainers are active.
+- Content PRs are reviewed for accuracy, beginner clarity, source quality, and bilingual consistency.
+- Product PRs are reviewed for tests, accessibility, mobile behavior, and build impact.
+- Growth PRs are reviewed for audience fit, credibility, and whether they strengthen the project brand.
+
+## Recognition Loop
+
+Every monthly growth report should include:
+
+- New contributors and useful first PRs.
+- Repeat contributors who moved up the ladder.
+- Modules with active stewards or needed stewards.
+- Best community posts, submissions, or partner leads.
+- Star count, fork count, contributor count, and sponsor pipeline movement.
+
+## Maintainer Checklist
+
+- Label starter work with `good first issue` only when the issue has clear acceptance criteria.
+- Add `help wanted` when outside review or domain expertise would materially help.
+- Split large ideas into small issues before assigning them to first-time contributors.
+- Convert repeated questions into docs, lesson FAQs, or issue template improvements.
+- Do not promise sponsorship placement, token promotion, or financial endorsement in contributor threads.

--- a/docs/community/good-first-issues.md
+++ b/docs/community/good-first-issues.md
@@ -1,0 +1,188 @@
+# Good First Issues Catalog
+
+> 中文说明：这份清单用于快速创建公开 GitHub Issues。每条都包含建议标题、标签、背景、验收标准和验证方式。
+
+Use this catalog to seed issues that a newcomer can complete without deep repository context. Copy one item into GitHub Issues, keep the acceptance criteria, and add links to the affected files.
+
+## Labels
+
+Use these labels consistently:
+
+- `good first issue`: small, clear, and safe for a first PR.
+- `help wanted`: useful for outside contributors, reviewers, or domain experts.
+- `content`: lesson, translation, quiz, glossary, or source quality.
+- `ai-native`: `llms.txt`, manifest, content index, MCP, or agent citation work.
+- `growth`: distribution, community, SEO, sponsorship, or public positioning.
+
+## Seed Issues
+
+### 1. Proofread One English Web3 Quick Start Lesson
+
+**Labels:** `good first issue`, `content`
+
+**Context:** Some English lessons were translated from Chinese and can be made more natural for global beginners.
+
+**Acceptance criteria:**
+
+- Pick one file under `en/Web3QuickStart/`.
+- Improve clarity without changing technical meaning.
+- Keep headings and relative links working.
+- Mention the file path in the PR description.
+
+**Verification:** Markdown preview or local app review.
+
+### 2. Add Source Links To One DeFi Lesson
+
+**Labels:** `good first issue`, `content`
+
+**Context:** DeFi lessons are more credible when major mechanism claims link to canonical docs or reputable explainers.
+
+**Acceptance criteria:**
+
+- Pick one file under `en/DeFiDeepDive/` or `zh/DeFiDeepDive/`.
+- Add 3-5 source links for protocol mechanics, risk explanations, or definitions.
+- Avoid promotional referral links in lesson body.
+- Keep beginner language readable.
+
+**Verification:** Check all links open.
+
+### 3. Add Two Glossary Terms For Smart Accounts
+
+**Labels:** `good first issue`, `content`
+
+**Context:** The smart-account module introduces terms that should also be searchable from the glossary.
+
+**Acceptance criteria:**
+
+- Add two terms to `src/config/glossaryData.js`.
+- Use an existing glossary category.
+- Add or update tests in `src/config/__tests__/glossaryData.test.js` if category coverage changes.
+
+**Verification:** `npm test -- src/config/__tests__/glossaryData.test.js`
+
+### 4. Add Quiz Questions For A Builder Lab Lesson
+
+**Labels:** `good first issue`, `content`
+
+**Context:** Builder lessons should reinforce practical understanding with short checks.
+
+**Acceptance criteria:**
+
+- Add at least three questions to `src/features/quiz/quizData.js`.
+- Questions should test applied understanding, not trivia.
+- Include one question about a common beginner mistake.
+
+**Verification:** `npm test`
+
+### 5. Improve Mobile Readability On One Course Page
+
+**Labels:** `good first issue`, `help wanted`
+
+**Context:** Dense educational pages need to remain readable on small screens.
+
+**Acceptance criteria:**
+
+- Pick one course page or reusable component.
+- Improve spacing, wrapping, or touch target size.
+- Include before/after screenshots in the PR.
+- Avoid broad redesigns.
+
+**Verification:** `npm test`, `npm run lint`, screenshot at mobile width.
+
+### 6. Add AI Citation Notes To One Lesson
+
+**Labels:** `good first issue`, `ai-native`, `content`
+
+**Context:** AI agents work better when lessons have clear source context and stable citations.
+
+**Acceptance criteria:**
+
+- Pick one lesson with protocol facts.
+- Add a short "Further reading" or source section.
+- Regenerate AI artifacts if lesson metadata or indexed content changes.
+
+**Verification:** `npm run ai:index && npm run ai:publish && npm run ai:verify`
+
+### 7. Check One Public AI Entrypoint
+
+**Labels:** `good first issue`, `ai-native`
+
+**Context:** Public agent entrypoints should stay accurate after content updates.
+
+**Acceptance criteria:**
+
+- Open the live `llms.txt`, AI manifest, and AI content index.
+- Report stale copy, broken URLs, or confusing descriptions.
+- Fix the issue if it is a small docs/artifact problem.
+
+**Verification:** `npm run ai:verify`
+
+### 8. Submit The Project To One Awesome List
+
+**Labels:** `good first issue`, `growth`
+
+**Context:** Curated list submissions help the project reach learners who do not follow the maintainer yet.
+
+**Acceptance criteria:**
+
+- Pick one target from `docs/strategy/2026-05-14-awesome-list-submissions.md`.
+- Open a PR or issue on the target list when their rules allow it.
+- Record the link and status back in a project issue or PR.
+
+**Verification:** Link to the external submission.
+
+### 9. Write A Short Community Post Draft
+
+**Labels:** `good first issue`, `growth`
+
+**Context:** Reusable post drafts make weekly distribution easier.
+
+**Acceptance criteria:**
+
+- Draft one 150-300 word post for Twitter/X, Farcaster, Reddit, or a Chinese Web3 community.
+- Include one concrete learning outcome and one link to the live site.
+- Avoid financial advice, token promotion, or trading claims.
+
+**Verification:** Maintainer review.
+
+### 10. Add A Lesson Screenshot Or Diagram
+
+**Labels:** `good first issue`, `content`
+
+**Context:** Some beginner concepts need visuals to reduce cognitive load.
+
+**Acceptance criteria:**
+
+- Pick a lesson where a visual would clarify a workflow.
+- Add one image or diagram with alt text.
+- Keep file size reasonable and use relative paths.
+
+**Verification:** Local Markdown/app preview.
+
+### 11. Audit One Lesson For Security Warnings
+
+**Labels:** `good first issue`, `content`
+
+**Context:** Beginner Web3 content must clearly mark risky actions.
+
+**Acceptance criteria:**
+
+- Pick one wallet, bridge, DeFi, or token lesson.
+- Add or refine warnings for private keys, approvals, phishing, bridge risk, or smart contract risk.
+- Keep tone practical and non-alarmist.
+
+**Verification:** Maintainer review.
+
+### 12. Improve The Sponsor Kit With One Comparable Project
+
+**Labels:** `good first issue`, `growth`
+
+**Context:** Sponsorship positioning improves when the project can compare itself with similar education/community assets.
+
+**Acceptance criteria:**
+
+- Add one comparable project, newsletter, course, or community reference to sponsor research notes.
+- Include public metrics if available.
+- Do not fabricate traffic, conversion, or audience data.
+
+**Verification:** Link to the public source.

--- a/docs/superpowers/plans/2026-05-14-contributor-growth-system.md
+++ b/docs/superpowers/plans/2026-05-14-contributor-growth-system.md
@@ -1,0 +1,104 @@
+# Contributor Growth System Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a public contribution system that converts GitHub visitors into first-time contributors and repeat community participants.
+
+**Architecture:** Keep the first version as static repository assets: contribution guides, community docs, issue templates, and the PR template. This avoids runtime risk while improving discoverability, triage quality, and community trust.
+
+**Tech Stack:** Markdown, GitHub issue forms, GitHub pull request template, Prettier.
+
+---
+
+### Task 1: Community Docs
+
+**Files:**
+
+- Create: `docs/community/contributor-ladder.md`
+- Create: `docs/community/good-first-issues.md`
+
+- [ ] **Step 1: Add the contributor ladder**
+
+Create `docs/community/contributor-ladder.md` with roles for first-time contributors, repeat contributors, reviewers, module stewards, and sponsor/community partners. Include review rhythm, recognition rules, and quality expectations.
+
+- [ ] **Step 2: Add seed issues**
+
+Create `docs/community/good-first-issues.md` with copy-ready GitHub issue titles, labels, context, acceptance criteria, and verification commands for translation, glossary, quiz, SEO, AI-native, and community distribution work.
+
+- [ ] **Step 3: Verify docs are actionable**
+
+Run: `npx prettier --check docs/community/contributor-ladder.md docs/community/good-first-issues.md`
+
+Expected: both files pass formatting.
+
+### Task 2: Contribution Guides
+
+**Files:**
+
+- Modify: `CONTRIBUTING.md`
+- Modify: `CONTRIBUTING.en.md`
+
+- [ ] **Step 1: Add contribution tracks**
+
+Update both guides with a short track selector covering content, translation, quiz/glossary, product bug, AI-native artifact, and growth contribution paths.
+
+- [ ] **Step 2: Add validation matrix**
+
+Update both guides with exact commands for content-only changes, course structure changes, UI/code changes, and AI-native changes.
+
+- [ ] **Step 3: Link community docs**
+
+Link the contributor ladder and good-first-issues catalog from both guides.
+
+### Task 3: GitHub Templates
+
+**Files:**
+
+- Create: `.github/ISSUE_TEMPLATE/config.yml`
+- Create: `.github/ISSUE_TEMPLATE/content_contribution.yml`
+- Create: `.github/ISSUE_TEMPLATE/growth_distribution.yml`
+- Modify: `.github/ISSUE_TEMPLATE/bug_report.yml`
+- Modify: `.github/ISSUE_TEMPLATE/feature_request.yml`
+- Modify: `.github/PULL_REQUEST_TEMPLATE.md`
+
+- [ ] **Step 1: Add issue template config**
+
+Add template chooser guidance and external links to the live site, contributor guide, and good-first-issues catalog.
+
+- [ ] **Step 2: Add content contribution form**
+
+Add a bilingual form that captures language, module, lesson, contribution type, reader outcome, source links, and validation commands.
+
+- [ ] **Step 3: Add growth distribution form**
+
+Add a bilingual form that captures target audience, distribution channel, proposed copy, expected action, and owner.
+
+- [ ] **Step 4: Refresh existing forms**
+
+Update bug and feature templates with bilingual names, clearer labels, and categories aligned to the current product.
+
+- [ ] **Step 5: Refresh PR template**
+
+Update the PR template with bilingual sections and validation checkboxes for tests, lint, build, AI artifacts, screenshots, and docs.
+
+### Task 4: Agent Notes And Verification
+
+**Files:**
+
+- Modify: `AGENTS.md`
+
+- [ ] **Step 1: Update agent notes**
+
+Add the new community docs and template surfaces to `AGENTS.md` so future agents maintain them when growth operations change.
+
+- [ ] **Step 2: Run verification**
+
+Run:
+
+```bash
+npx prettier --check CONTRIBUTING.md CONTRIBUTING.en.md AGENTS.md docs/community/*.md docs/superpowers/specs/2026-05-14-contributor-growth-system-design.md docs/superpowers/plans/2026-05-14-contributor-growth-system.md .github/ISSUE_TEMPLATE/*.yml .github/PULL_REQUEST_TEMPLATE.md
+git diff --check
+git status --short
+```
+
+Expected: Prettier and diff whitespace checks pass; status shows only the intended docs/template changes.

--- a/docs/superpowers/specs/2026-05-14-contributor-growth-system-design.md
+++ b/docs/superpowers/specs/2026-05-14-contributor-growth-system-design.md
@@ -1,0 +1,53 @@
+# Contributor Growth System Design
+
+## Context
+
+Get Started with Web3 now has a broader bilingual curriculum, AI-native entry points, and an explicit 1000-star growth target. The next bottleneck is turning GitHub visitors into contributors, repeat readers, and community advocates. The current contribution docs explain the mechanics of opening a PR, but they do not yet provide a clear contribution ladder, issue routing, or a public backlog that a newcomer can trust.
+
+## Goals
+
+- Help a first-time contributor find a useful task in five minutes.
+- Separate content, product, bug, and growth suggestions at issue intake.
+- Make maintainership expectations visible so contributors know what happens after they submit.
+- Give beihai reusable public assets for community posts, weekly updates, and issue seeding.
+
+## Non-Goals
+
+- No changes to payment, sponsorship acceptance, or wallet addresses.
+- No changes to GitHub repository permissions, branch protection, or release settings.
+- No new runtime product behavior.
+
+## Approach
+
+Use documentation and GitHub templates as the first version of the contributor growth system. This is intentionally low risk: it improves public onboarding without requiring database changes, GitHub app automation, or external service dependencies.
+
+The system has four surfaces:
+
+1. `CONTRIBUTING.md` and `CONTRIBUTING.en.md` become the short operational guide.
+2. `docs/community/contributor-ladder.md` explains contributor roles, review rhythm, recognition, and quality expectations.
+3. `docs/community/good-first-issues.md` provides seed issue titles with acceptance criteria that can be copied into GitHub Issues.
+4. `.github/ISSUE_TEMPLATE/*` and `.github/PULL_REQUEST_TEMPLATE.md` route incoming work into content, product, bug, and growth lanes.
+
+## Contributor Flow
+
+1. A visitor lands on the README and clicks the contribution link.
+2. They choose a contribution track: typo/translation, lesson improvement, quiz/glossary, AI-native artifact, product bug, or growth distribution.
+3. They open a matching issue or pick a seed issue from the good-first-issues catalog.
+4. The PR template asks for the relevant validation commands and content checks.
+5. Maintainers review against the visible ladder and recognition rules.
+
+## Quality Bar
+
+Content changes must name the affected language, module, lesson, and reader outcome. Product changes must include the related test or a reason tests are not applicable. AI-native changes must mention whether `npm run ai:index`, `npm run ai:publish`, or `npm run ai:verify` was run. Growth suggestions must include the target audience, distribution channel, and expected next action.
+
+## Testing
+
+This is a documentation/template change. Verification is:
+
+- Markdown/YAML files format cleanly with Prettier where supported.
+- Git status contains only the intended docs and GitHub template files.
+- Existing project lint is not required for static docs, but may be run if code files are touched.
+
+## Approval
+
+beihai delegated routine project approval to Codex for growth work. This design is self-approved because it is reversible, does not alter funding or security settings, and directly supports the 1000-star operating goal.


### PR DESCRIPTION
## Summary
- Adds a public contributor ladder and copy-ready good first issue catalog.
- Refreshes contribution guides, issue forms, and PR template for content, AI-native, and growth work.
- Links the new community entry points from README files and AGENTS notes.

## Verification
- npx prettier --check README.md README.zh.md CONTRIBUTING.md CONTRIBUTING.en.md AGENTS.md docs/community/*.md docs/superpowers/specs/2026-05-14-contributor-growth-system-design.md docs/superpowers/plans/2026-05-14-contributor-growth-system.md .github/ISSUE_TEMPLATE/*.yml .github/PULL_REQUEST_TEMPLATE.md
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/ISSUE_TEMPLATE/*.yml
- git diff --check
- npm test
- npm run lint

## Operations
- Created repository labels `growth` and `ai-native` so the new issue templates can route work correctly.