### PR TITLE
docs: draft community distribution posts

### DIFF
--- a/docs/strategy/2026-05-14-awesome-list-submissions.md
+++ b/docs/strategy/2026-05-14-awesome-list-submissions.md
@@ -45,8 +45,8 @@ Do not submit to spammy lists, paid-only lists, or repositories with no recent m
 | awesome-mcp                  | MCP               | Read-only Web3 curriculum MCP             | Submitted   | Track TensorBlock/awesome-mcp-servers#544   |
 | awesome-llms-txt             | AI agent content  | Public `llms.txt` entrypoint              | Not started | Check if education repos are accepted       |
 | awesome-ai-agents            | AI agents         | Agent-readable curriculum                 | Not started | Check if MCP resources are accepted         |
-| learnblockchain.cn/community | Chinese community | Existing referrer and strong audience fit | Not started | Prepare Chinese community post              |
-| Twitter/X thread             | Personal brand    | Fastest direct distribution               | Not started | Use public post draft queue                 |
+| learnblockchain.cn/community | Chinese community | Existing referrer and strong audience fit | Drafted     | Publish from public post draft queue        |
+| Twitter/X thread             | Personal brand    | Fastest direct distribution               | Drafted     | Publish from public post draft queue        |
 
 ## Pull Request Template For Awesome Lists
 

--- a/docs/strategy/2026-05-14-execution-board.md
+++ b/docs/strategy/2026-05-14-execution-board.md
@@ -119,10 +119,12 @@ Update weekly.
 7. Add contributor ladder to CONTRIBUTING.
 8. Draft public roadmap issue.
 9. Close or classify translation coverage warnings.
-10. Draft and publish first 4 low-risk public posts, with links recorded in daily reports.
+10. In progress: draft and publish first 4 low-risk public posts, with links recorded in daily reports.
 
 ## Public Post Draft Queue
 
+- [x] Chinese Web3 community starter post: `docs/strategy/2026-05-15-public-post-drafts.md`
+- [x] X/Farcaster AI-native curriculum thread: `docs/strategy/2026-05-15-public-post-drafts.md`
 - [ ] "I turned my Web3 learning repo into an AI-readable curriculum with llms.txt + MCP."
 - [ ] "A beginner-safe route from wallet creation to first DApp, DeFi, L2 and DAO."
 - [ ] "How agents can search and cite a Web3 curriculum instead of hallucinating."

--- a/docs/strategy/2026-05-15-public-post-drafts.md
+++ b/docs/strategy/2026-05-15-public-post-drafts.md
@@ -1,0 +1,71 @@
+# Public Post Drafts
+
+**Date:** 2026-05-15
+**Owner:** beihai + Codex
+**Status:** Ready for maintainer review and publishing
+
+## Publishing Rules
+
+- Do not make financial advice, trading claims, token recommendations, or sponsored claims.
+- Always include one concrete learner outcome and one canonical project link.
+- Record any published link, channel, date, and visible engagement metric in this file.
+- Reuse drafts across channels only after adapting length, tone, and community norms.
+
+## Draft 1: Chinese Web3 Community
+
+**Target channel:** Chinese Web3 learning communities, learnblockchain.cn community, WeChat groups, Telegram groups.
+**Audience:** Chinese-speaking beginners and builders who want a structured, safer Web3 learning path.
+**Concrete learner outcome:** A newcomer can complete a first learning path from wallet identity to first DApp, then understand the basics of Bitcoin, Ethereum, DeFi, Layer 2, DAO, and smart accounts without relying on fragmented links.
+**Status:** Drafted, not published.
+
+```markdown
+我在持续维护一个开源 Web3 学习项目：Get Started with Web3。
+
+它已经从早期教程仓库升级成一个双语、AI-native 的 Web3 学习平台，适合想系统入门的新人和准备动手做项目的 builder。
+
+你可以按路线完成一个具体目标：从创建第一个 Web3 身份、体验第一笔交易和第一个 DApp 开始，再继续学习 Bitcoin、Ethereum、DeFi、Layer 2、DAO、智能账户和 Builder 实战。项目也提供搜索、测验、徽章、AI Tutor、术语表、llms.txt、内容索引和本地只读 MCP server，方便人和 AI agent 都能引用课程内容。
+
+在线学习：https://beihaili.github.io/Get-Started-with-Web3/
+
+如果你正在学 Web3，欢迎 star、提 issue、校对翻译或补充安全提示。项目会继续公开迭代，不做交易建议，也不推广任何 token。
+```
+
+## Draft 2: X / Farcaster Thread
+
+**Target channel:** Twitter/X and Farcaster.
+**Audience:** English-speaking Web3 learners, builders, and AI-agent developers.
+**Concrete learner outcome:** A learner or agent can follow a cited path through 58 lessons and retrieve curriculum context through `llms.txt` or the read-only MCP server.
+**Status:** Backup draft, not published.
+
+```markdown
+1/ I am turning Get Started with Web3 into an open-source, bilingual, AI-native Web3 curriculum.
+
+It now covers wallets, first transactions, Bitcoin, Ethereum, DeFi, Layer 2, DAO, smart accounts, builder labs, security basics, and glossary entries.
+
+2/ The concrete learner outcome:
+
+Start from creating your first Web3 identity and using your first DApp, then follow a structured path toward understanding Bitcoin, Ethereum, DeFi, L2s, DAOs, and account abstraction.
+
+3/ The AI-native layer is part of the product:
+
+- llms.txt
+- AI manifest
+- content index
+- local read-only MCP server
+- citation-ready context packs
+
+This helps AI tutors and coding agents search and cite the curriculum instead of guessing.
+
+4/ Live site:
+https://beihaili.github.io/Get-Started-with-Web3/
+
+Repo:
+https://github.com/beihaili/Get-Started-with-Web3
+
+Open to contributors for translations, source links, safety notes, examples, and beginner-friendly issue fixes.
+```
+
+## Publication Log
+
+| Date | Channel | Link | Status | Visible Metrics | Notes |
+| ---- | ------- | ---- | ------ | --------------- | ----- |


### PR DESCRIPTION
## Summary
- Add reusable public post drafts for a Chinese Web3 community post and an X/Farcaster thread.
- Update the execution board public post queue.
- Mark Chinese community and Twitter/X distribution targets as drafted.

Closes #123.

## Verification
- `npx prettier --check docs/strategy/2026-05-15-public-post-drafts.md docs/strategy/2026-05-14-execution-board.md docs/strategy/2026-05-14-awesome-list-submissions.md`
- `git diff --check`
- `npm test`
- `npm run lint`