### PR TITLE
feat: export learning progress as JSON

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,12 @@ npm run mcp:web3        # 启动本地 stdio MCP server
 
 修改课程结构、术语表或 Agent 工具元数据后，运行 `npm run ai:index && npm run ai:publish && npm run ai:verify`，并提交更新后的 `ai/` 与 `public/` artifacts。
 
+## 学习进度导出
+
+- `src/components/ProgressExport.jsx`: Dashboard 概览区的学习进度 JSON 导出按钮，所有文案走 `dashboard.*` i18n key。
+- `src/utils/progressExport.js`: 导出 schema 与浏览器下载逻辑，当前 payload 为 `{ version, exportedAt, data }`，`data` 只包含 `useUserStore` 中的非敏感学习进度字段。
+- 后续实现导入进度时，应优先复用 `progressExport.js` 的 schema 字段，避免导入/导出结构分叉。
+
 ## MCP Server
 
 `scripts/web3-mcp-server.mjs` 使用官方 `@modelcontextprotocol/sdk` 暴露本地 stdio MCP server。该 server 是只读的，不应写文件、修改课程内容或执行链上操作。

--- a/src/components/ProgressExport.jsx
+++ b/src/components/ProgressExport.jsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { Download } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useUserStore } from '../store/useUserStore';
+import { downloadProgressExport } from '../utils/progressExport';
+
+const ProgressExport = () => {
+  const { t } = useTranslation();
+  const [exportStarted, setExportStarted] = useState(false);
+
+  const handleExport = () => {
+    downloadProgressExport(useUserStore.getState());
+    setExportStarted(true);
+  };
+
+  return (
+    <div className="flex flex-col items-start gap-2 sm:items-end">
+      <button
+        type="button"
+        onClick={handleExport}
+        className="inline-flex items-center gap-2 rounded-lg border border-cyan-500/30 bg-cyan-500/10 px-3 py-2 text-sm font-medium text-cyan-700 transition-colors hover:border-cyan-500/50 hover:bg-cyan-500/15 dark:text-cyan-300"
+      >
+        <Download className="h-4 w-4" />
+        <span>{t('dashboard.exportProgress')}</span>
+      </button>
+      {exportStarted && (
+        <p className="text-xs text-slate-500 dark:text-slate-400" role="status">
+          {t('dashboard.exportStarted')}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default ProgressExport;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -46,7 +46,9 @@
     "statCompleted": "Completed Courses",
     "statStreak": "Study Streak",
     "streakDays": "{{count}} days",
-    "lessonsCount": "{{count}} lessons"
+    "lessonsCount": "{{count}} lessons",
+    "exportProgress": "Export progress",
+    "exportStarted": "Progress export started."
   },
   "reader": {
     "pageDescSuffix": "tutorial",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -46,7 +46,9 @@
     "statCompleted": "已完成课程",
     "statStreak": "连续学习",
     "streakDays": "{{count}} 天",
-    "lessonsCount": "{{count}} 讲课程"
+    "lessonsCount": "{{count}} 讲课程",
+    "exportProgress": "导出进度",
+    "exportStarted": "进度导出已开始。"
   },
   "reader": {
     "pageDescSuffix": "教程",

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -9,6 +9,7 @@ import LanguageSwitcher from '../components/LanguageSwitcher';
 import ThemeToggle from '../components/ThemeToggle';
 import MobileNav from '../components/MobileNav';
 import SeoHead from '../components/SeoHead';
+import ProgressExport from '../components/ProgressExport';
 
 /**
  * 仪表板页面
@@ -100,9 +101,12 @@ const DashboardPage = () => {
       <main className="container mx-auto px-4 py-8">
         {/* User Stats */}
         <div className="mb-8 p-6 bg-white/60 dark:bg-slate-900/60 backdrop-blur-md border border-slate-200/50 dark:border-slate-700/50 rounded-xl">
-          <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">
-            {t('dashboard.overviewTitle')}
-          </h2>
+          <div className="mb-4 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">
+              {t('dashboard.overviewTitle')}
+            </h2>
+            <ProgressExport />
+          </div>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
             <div className="flex items-center gap-3">
               <div className="w-12 h-12 rounded-full bg-cyan-500/10 flex items-center justify-center">

--- a/src/pages/__tests__/DashboardPage.test.jsx
+++ b/src/pages/__tests__/DashboardPage.test.jsx
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import DashboardPage from '../DashboardPage';
+import LanguageProvider from '../../i18n/LanguageProvider';
+import { useUserStore } from '../../store/useUserStore';
+import '../../i18n';
+
+function renderDashboard(initialEntry = '/en/dashboard') {
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route
+          path="/:lang/dashboard"
+          element={
+            <LanguageProvider>
+              <DashboardPage />
+            </LanguageProvider>
+          }
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('DashboardPage progress export', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    useUserStore.setState({
+      progress: { 'module-1-1-1': true, 'module-2-2-1': true },
+      earnedBadges: {
+        starter: { moduleId: 'module-1', timestamp: 1778812000000 },
+      },
+      totalExperience: 1200,
+      userTitle: 'Web3 学徒',
+      studyStreak: 4,
+      lastStudyDate: 'Fri May 15 2026',
+      quizScores: {
+        '1-1': { score: 3, total: 3, isPerfect: true },
+      },
+      firstActivityTimestamp: 1778810000000,
+    });
+  });
+
+  it('downloads a parseable JSON progress snapshot with today in the filename', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-15T09:30:00.000Z'));
+
+    const createdUrls = [];
+    vi.spyOn(URL, 'createObjectURL').mockImplementation((blob) => {
+      createdUrls.push(blob);
+      return 'blob:progress-export';
+    });
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+    const clickedLinks = [];
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tagName, options) => {
+      const element = originalCreateElement(tagName, options);
+      if (tagName.toLowerCase() === 'a') {
+        vi.spyOn(element, 'click').mockImplementation(() => {
+          clickedLinks.push({
+            download: element.download,
+            href: element.href,
+          });
+        });
+      }
+      return element;
+    });
+
+    renderDashboard();
+    fireEvent.click(screen.getByRole('button', { name: /export progress/i }));
+
+    expect(clickedLinks).toEqual([
+      {
+        download: 'web3-progress-2026-05-15.json',
+        href: 'blob:progress-export',
+      },
+    ]);
+
+    const exportedText = await createdUrls[0].text();
+    const exportedJson = JSON.parse(exportedText);
+
+    expect(exportedJson).toMatchObject({
+      version: 1,
+      exportedAt: '2026-05-15T09:30:00.000Z',
+      data: {
+        progress: { 'module-1-1-1': true, 'module-2-2-1': true },
+        earnedBadges: {
+          starter: { moduleId: 'module-1', timestamp: 1778812000000 },
+        },
+        totalExperience: 1200,
+        userTitle: 'Web3 学徒',
+        studyStreak: 4,
+        lastStudyDate: 'Fri May 15 2026',
+        quizScores: {
+          '1-1': { score: 3, total: 3, isPerfect: true },
+        },
+        firstActivityTimestamp: 1778810000000,
+      },
+    });
+
+    expect(screen.getByText('Progress export started.')).toBeInTheDocument();
+  });
+});

--- a/src/utils/progressExport.js
+++ b/src/utils/progressExport.js
@@ -1,0 +1,48 @@
+export const PROGRESS_EXPORT_VERSION = 1;
+
+const PROGRESS_EXPORT_FIELDS = [
+  'progress',
+  'earnedBadges',
+  'totalExperience',
+  'userTitle',
+  'studyStreak',
+  'lastStudyDate',
+  'quizScores',
+  'firstActivityTimestamp',
+];
+
+export function buildProgressExport(state, exportedAt = new Date()) {
+  const data = PROGRESS_EXPORT_FIELDS.reduce((snapshot, field) => {
+    snapshot[field] = state[field] ?? null;
+    return snapshot;
+  }, {});
+
+  return {
+    version: PROGRESS_EXPORT_VERSION,
+    exportedAt: exportedAt.toISOString(),
+    data,
+  };
+}
+
+export function getProgressExportFileName(exportedAt = new Date()) {
+  return `web3-progress-${exportedAt.toISOString().slice(0, 10)}.json`;
+}
+
+export function downloadProgressExport(state, exportedAt = new Date()) {
+  const payload = buildProgressExport(state, exportedAt);
+  const fileName = getProgressExportFileName(exportedAt);
+  const blob = new Blob([JSON.stringify(payload, null, 2)], {
+    type: 'application/json',
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+
+  link.href = url;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+
+  return { fileName, payload };
+}


### PR DESCRIPTION
## Summary

- Add a Dashboard export button that downloads a JSON snapshot of non-sensitive learning progress.
- Add `src/utils/progressExport.js` with versioned export payloads and `web3-progress-YYYY-MM-DD.json` file naming.
- Add dashboard i18n strings in English and Chinese, plus an integration test for the download blob and confirmation message.
- Update `AGENTS.md` with the new export schema note for the future import flow.

Closes #94

## Verification

- Red check first: `npx vitest run src/pages/__tests__/DashboardPage.test.jsx` failed because the export button did not exist.
- Green check: `npx vitest run src/pages/__tests__/DashboardPage.test.jsx`
- `npx prettier --check AGENTS.md src/components/ProgressExport.jsx src/pages/DashboardPage.jsx src/pages/__tests__/DashboardPage.test.jsx src/utils/progressExport.js src/i18n/locales/en.json src/i18n/locales/zh.json`
- `git diff --check`
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run ai:verify`