### PR TITLE
feat: import learning progress from JSON

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,11 +61,12 @@ npm run mcp:web3        # 启动本地 stdio MCP server
 
 修改课程结构、术语表或 Agent 工具元数据后，运行 `npm run ai:index && npm run ai:publish && npm run ai:verify`，并提交更新后的 `ai/` 与 `public/` artifacts。
 
-## 学习进度导出
+## 学习进度导入/导出
 
 - `src/components/ProgressExport.jsx`: Dashboard 概览区的学习进度 JSON 导出按钮，所有文案走 `dashboard.*` i18n key。
+- `src/components/ProgressImport.jsx`: Dashboard 概览区的学习进度 JSON 导入按钮，负责文件选择、错误提示，以及本地已有进度时的替换/合并/取消对话框。
 - `src/utils/progressExport.js`: 导出 schema 与浏览器下载逻辑，当前 payload 为 `{ version, exportedAt, data }`，`data` 只包含 `useUserStore` 中的非敏感学习进度字段。
-- 后续实现导入进度时，应优先复用 `progressExport.js` 的 schema 字段，避免导入/导出结构分叉。
+- `src/utils/mergeProgress.js`: 导入 schema 校验、进度归一化和纯合并逻辑；合并规则需保持可测试，避免在 UI 组件里写业务合并逻辑。
 
 ## MCP Server
 

--- a/src/components/ProgressImport.jsx
+++ b/src/components/ProgressImport.jsx
@@ -1,0 +1,155 @@
+import { useRef, useState } from 'react';
+import { Upload } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useUserStore } from '../store/useUserStore';
+import {
+  isProgressDataEmpty,
+  mergeProgress,
+  normalizeProgressData,
+  parseProgressImportPayload,
+  ProgressImportError,
+} from '../utils/mergeProgress';
+
+function readFileText(file) {
+  if (typeof file.text === 'function') {
+    return file.text();
+  }
+
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(file);
+  });
+}
+
+const ProgressImport = () => {
+  const { t } = useTranslation();
+  const inputRef = useRef(null);
+  const [errorKey, setErrorKey] = useState(null);
+  const [statusKey, setStatusKey] = useState(null);
+  const [pendingProgress, setPendingProgress] = useState(null);
+
+  const clearMessages = () => {
+    setErrorKey(null);
+    setStatusKey(null);
+  };
+
+  const applyImport = (mode, incoming = pendingProgress) => {
+    if (!incoming) return;
+
+    const currentProgress = normalizeProgressData(useUserStore.getState());
+    const nextProgress = mode === 'merge' ? mergeProgress(currentProgress, incoming) : incoming;
+
+    useUserStore.setState(nextProgress);
+    setPendingProgress(null);
+    setStatusKey(mode === 'merge' ? 'dashboard.importMerged' : 'dashboard.imported');
+  };
+
+  const handleFileChange = async (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    clearMessages();
+
+    try {
+      const text = await readFileText(file);
+      const parsed = parseProgressImportPayload(JSON.parse(text));
+      const currentProgress = normalizeProgressData(useUserStore.getState());
+
+      if (isProgressDataEmpty(currentProgress)) {
+        applyImport('replace', parsed);
+      } else {
+        setPendingProgress(parsed);
+      }
+    } catch (error) {
+      const key =
+        error instanceof ProgressImportError && error.code === 'unsupported-version'
+          ? 'dashboard.importUnsupportedVersion'
+          : 'dashboard.importInvalidJson';
+      setPendingProgress(null);
+      setErrorKey(key);
+    } finally {
+      event.target.value = '';
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-start gap-2 sm:items-end">
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".json"
+        className="sr-only"
+        aria-label={t('dashboard.importFileLabel')}
+        onChange={handleFileChange}
+      />
+      <button
+        type="button"
+        onClick={() => inputRef.current?.click()}
+        className="inline-flex items-center gap-2 rounded-lg border border-purple-500/30 bg-purple-500/10 px-3 py-2 text-sm font-medium text-purple-700 transition-colors hover:border-purple-500/50 hover:bg-purple-500/15 dark:text-purple-300"
+      >
+        <Upload className="h-4 w-4" />
+        <span>{t('dashboard.importProgress')}</span>
+      </button>
+      {errorKey && (
+        <p className="max-w-xs text-xs text-rose-500 dark:text-rose-300" role="alert">
+          {t(errorKey)}
+        </p>
+      )}
+      {statusKey && (
+        <p className="text-xs text-slate-500 dark:text-slate-400" role="status">
+          {t(statusKey)}
+        </p>
+      )}
+      {pendingProgress && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="progress-import-title"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/60 px-4"
+        >
+          <div className="w-full max-w-md rounded-xl border border-slate-200 bg-white p-6 shadow-xl dark:border-slate-700 dark:bg-slate-900">
+            <h3
+              id="progress-import-title"
+              className="text-lg font-bold text-slate-900 dark:text-white"
+            >
+              {t('dashboard.importDialogTitle')}
+            </h3>
+            <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+              {t('dashboard.importDialogDesc')}
+            </p>
+            <div className="mt-6 flex flex-col gap-2 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                onClick={() => {
+                  setPendingProgress(null);
+                  setStatusKey('dashboard.importCanceled');
+                }}
+                className="rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+              >
+                {t('dashboard.importCancel')}
+              </button>
+              <button
+                type="button"
+                onClick={() => applyImport('replace')}
+                className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm font-medium text-rose-600 hover:bg-rose-500/15 dark:text-rose-300"
+              >
+                {t('dashboard.importReplace')}
+              </button>
+              <button
+                type="button"
+                onClick={() => applyImport('merge')}
+                className="rounded-lg border border-cyan-500/30 bg-cyan-500/10 px-3 py-2 text-sm font-medium text-cyan-700 hover:bg-cyan-500/15 dark:text-cyan-300"
+              >
+                {t('dashboard.importMerge')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ProgressImport;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -48,7 +48,19 @@
     "streakDays": "{{count}} days",
     "lessonsCount": "{{count}} lessons",
     "exportProgress": "Export progress",
-    "exportStarted": "Progress export started."
+    "exportStarted": "Progress export started.",
+    "importProgress": "Import progress",
+    "importFileLabel": "Import progress file",
+    "importInvalidJson": "Could not read this progress file. Choose a valid JSON export.",
+    "importUnsupportedVersion": "This progress file uses an unsupported version.",
+    "imported": "Progress imported.",
+    "importMerged": "Progress merged.",
+    "importCanceled": "Progress import canceled.",
+    "importDialogTitle": "Import progress",
+    "importDialogDesc": "Local progress already exists. Replace it, merge it, or cancel.",
+    "importReplace": "Replace",
+    "importMerge": "Merge",
+    "importCancel": "Cancel"
   },
   "reader": {
     "pageDescSuffix": "tutorial",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -48,7 +48,19 @@
     "streakDays": "{{count}} 天",
     "lessonsCount": "{{count}} 讲课程",
     "exportProgress": "导出进度",
-    "exportStarted": "进度导出已开始。"
+    "exportStarted": "进度导出已开始。",
+    "importProgress": "导入进度",
+    "importFileLabel": "导入进度文件",
+    "importInvalidJson": "无法读取这个进度文件，请选择有效的 JSON 导出文件。",
+    "importUnsupportedVersion": "这个进度文件使用了不支持的版本。",
+    "imported": "进度已导入。",
+    "importMerged": "进度已合并。",
+    "importCanceled": "进度导入已取消。",
+    "importDialogTitle": "导入进度",
+    "importDialogDesc": "本地已经有学习进度。你可以替换、合并或取消。",
+    "importReplace": "替换",
+    "importMerge": "合并",
+    "importCancel": "取消"
   },
   "reader": {
     "pageDescSuffix": "教程",

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -10,6 +10,7 @@ import ThemeToggle from '../components/ThemeToggle';
 import MobileNav from '../components/MobileNav';
 import SeoHead from '../components/SeoHead';
 import ProgressExport from '../components/ProgressExport';
+import ProgressImport from '../components/ProgressImport';
 
 /**
  * 仪表板页面
@@ -105,7 +106,10 @@ const DashboardPage = () => {
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">
               {t('dashboard.overviewTitle')}
             </h2>
-            <ProgressExport />
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+              <ProgressExport />
+              <ProgressImport />
+            </div>
           </div>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
             <div className="flex items-center gap-3">

--- a/src/pages/__tests__/DashboardPage.test.jsx
+++ b/src/pages/__tests__/DashboardPage.test.jsx
@@ -4,6 +4,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import DashboardPage from '../DashboardPage';
 import LanguageProvider from '../../i18n/LanguageProvider';
 import { useUserStore } from '../../store/useUserStore';
+import { buildProgressExport } from '../../utils/progressExport';
 import '../../i18n';
 
 function renderDashboard(initialEntry = '/en/dashboard') {
@@ -23,6 +24,18 @@ function renderDashboard(initialEntry = '/en/dashboard') {
   );
 }
 
+function createProgressFile(payload, name = 'web3-progress.json') {
+  return new File([JSON.stringify(payload)], name, {
+    type: 'application/json',
+  });
+}
+
+function uploadImportFile(file) {
+  fireEvent.change(screen.getByLabelText('Import progress file'), {
+    target: { files: [file] },
+  });
+}
+
 describe('DashboardPage progress export', () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -30,6 +43,7 @@ describe('DashboardPage progress export', () => {
   });
 
   beforeEach(() => {
+    localStorage.clear();
     useUserStore.setState({
       progress: { 'module-1-1-1': true, 'module-2-2-1': true },
       earnedBadges: {
@@ -105,5 +119,108 @@ describe('DashboardPage progress export', () => {
     });
 
     expect(screen.getByText('Progress export started.')).toBeInTheDocument();
+  });
+});
+
+describe('DashboardPage progress import', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    useUserStore.setState({
+      progress: {},
+      earnedBadges: {},
+      totalExperience: 0,
+      userTitle: '新手探索者',
+      studyStreak: 0,
+      lastStudyDate: null,
+      quizScores: {},
+      firstActivityTimestamp: null,
+    });
+  });
+
+  it('shows a friendly error for invalid JSON files', async () => {
+    const invalidFile = new File(['{not json'], 'broken.json', { type: 'application/json' });
+
+    renderDashboard();
+    uploadImportFile(invalidFile);
+
+    expect(
+      await screen.findByText('Could not read this progress file. Choose a valid JSON export.')
+    ).toBeInTheDocument();
+    expect(useUserStore.getState().progress).toEqual({});
+  });
+
+  it('rejects unsupported export versions with an inline error', async () => {
+    renderDashboard();
+    uploadImportFile(createProgressFile({ version: 999, data: {} }));
+
+    expect(
+      await screen.findByText('This progress file uses an unsupported version.')
+    ).toBeInTheDocument();
+    expect(useUserStore.getState().progress).toEqual({});
+  });
+
+  it('imports an exported progress snapshot when local progress is empty', async () => {
+    const exportedState = {
+      progress: { 'module-1-1-1': true },
+      earnedBadges: { starter: { moduleId: 'module-1', timestamp: 1778812000000 } },
+      totalExperience: 1200,
+      userTitle: 'Web3 学徒',
+      studyStreak: 4,
+      lastStudyDate: 'Fri May 15 2026',
+      quizScores: { '1-1': { score: 3, total: 3, isPerfect: true } },
+      firstActivityTimestamp: 1778810000000,
+    };
+    const file = createProgressFile(buildProgressExport(exportedState));
+
+    renderDashboard();
+    uploadImportFile(file);
+
+    expect(await screen.findByText('Progress imported.')).toBeInTheDocument();
+    expect(useUserStore.getState()).toMatchObject(exportedState);
+  });
+
+  it('prompts for merge when local progress exists and applies the merge choice', async () => {
+    useUserStore.setState({
+      progress: { 'module-1-1-1': true },
+      earnedBadges: {},
+      totalExperience: 500,
+      userTitle: 'Web3 学徒',
+      studyStreak: 2,
+      lastStudyDate: 'Thu May 14 2026',
+      quizScores: {},
+      firstActivityTimestamp: 1778800000000,
+    });
+    const incoming = {
+      progress: { 'module-2-2-1': true },
+      earnedBadges: { bitcoin: { moduleId: 'module-2', timestamp: 1778812000000 } },
+      totalExperience: 900,
+      userTitle: 'Web3 进阶者',
+      studyStreak: 1,
+      lastStudyDate: 'Fri May 15 2026',
+      quizScores: { '2-1': { score: 3, total: 3, isPerfect: true } },
+      firstActivityTimestamp: 1778790000000,
+    };
+
+    renderDashboard();
+    uploadImportFile(createProgressFile(buildProgressExport(incoming)));
+
+    expect(await screen.findByRole('dialog', { name: 'Import progress' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Merge' }));
+
+    expect(await screen.findByText('Progress merged.')).toBeInTheDocument();
+    expect(useUserStore.getState()).toMatchObject({
+      progress: { 'module-1-1-1': true, 'module-2-2-1': true },
+      earnedBadges: { bitcoin: { moduleId: 'module-2', timestamp: 1778812000000 } },
+      totalExperience: 900,
+      userTitle: 'Web3 进阶者',
+      studyStreak: 2,
+      lastStudyDate: 'Fri May 15 2026',
+      quizScores: { '2-1': { score: 3, total: 3, isPerfect: true } },
+      firstActivityTimestamp: 1778790000000,
+    });
   });
 });

--- a/src/utils/__tests__/mergeProgress.test.js
+++ b/src/utils/__tests__/mergeProgress.test.js
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { mergeProgress } from '../mergeProgress';
+
+describe('mergeProgress', () => {
+  it('keeps existing progress when incoming data is empty', () => {
+    const existing = {
+      progress: { 'module-1-1-1': true },
+      earnedBadges: { starter: { moduleId: 'module-1', timestamp: 10 } },
+      totalExperience: 300,
+      userTitle: 'Web3 学徒',
+      studyStreak: 3,
+      lastStudyDate: 'Fri May 15 2026',
+      quizScores: { '1-1': { score: 2, total: 3, isPerfect: false } },
+      firstActivityTimestamp: 100,
+    };
+
+    expect(mergeProgress(existing, {})).toEqual(existing);
+  });
+
+  it('uses incoming progress when existing data is empty', () => {
+    const incoming = {
+      progress: { 'module-2-2-1': true },
+      earnedBadges: { bitcoin: { moduleId: 'module-2', timestamp: 20 } },
+      totalExperience: 500,
+      userTitle: 'Web3 学徒',
+      studyStreak: 2,
+      lastStudyDate: 'Thu May 14 2026',
+      quizScores: { '2-1': { score: 3, total: 3, isPerfect: true } },
+      firstActivityTimestamp: 50,
+    };
+
+    expect(mergeProgress({}, incoming)).toEqual(incoming);
+  });
+
+  it('merges partial overlap using the more advanced value per field', () => {
+    const existing = {
+      progress: { 'module-1-1-1': true },
+      earnedBadges: { starter: { moduleId: 'module-1', timestamp: 10 } },
+      totalExperience: 700,
+      userTitle: 'Web3 学徒',
+      studyStreak: 2,
+      lastStudyDate: 'Thu May 14 2026',
+      quizScores: {
+        '1-1': { score: 2, total: 3, isPerfect: false },
+      },
+      firstActivityTimestamp: 100,
+    };
+    const incoming = {
+      progress: { 'module-1-1-1': true, 'module-2-2-1': true },
+      earnedBadges: {
+        starter: { moduleId: 'module-1', timestamp: 30 },
+        bitcoin: { moduleId: 'module-2', timestamp: 20 },
+      },
+      totalExperience: 900,
+      userTitle: 'Web3 进阶者',
+      studyStreak: 4,
+      lastStudyDate: 'Fri May 15 2026',
+      quizScores: {
+        '1-1': { score: 3, total: 3, isPerfect: true },
+        '2-1': { score: 1, total: 3, isPerfect: false },
+      },
+      firstActivityTimestamp: 80,
+    };
+
+    expect(mergeProgress(existing, incoming)).toEqual({
+      progress: { 'module-1-1-1': true, 'module-2-2-1': true },
+      earnedBadges: {
+        starter: { moduleId: 'module-1', timestamp: 30 },
+        bitcoin: { moduleId: 'module-2', timestamp: 20 },
+      },
+      totalExperience: 900,
+      userTitle: 'Web3 进阶者',
+      studyStreak: 4,
+      lastStudyDate: 'Fri May 15 2026',
+      quizScores: {
+        '1-1': { score: 3, total: 3, isPerfect: true },
+        '2-1': { score: 1, total: 3, isPerfect: false },
+      },
+      firstActivityTimestamp: 80,
+    });
+  });
+
+  it('keeps the longest streak and newest study date when streak timestamps conflict', () => {
+    const existing = {
+      studyStreak: 8,
+      lastStudyDate: 'Wed May 13 2026',
+    };
+    const incoming = {
+      studyStreak: 5,
+      lastStudyDate: 'Fri May 15 2026',
+    };
+
+    expect(mergeProgress(existing, incoming)).toMatchObject({
+      studyStreak: 8,
+      lastStudyDate: 'Fri May 15 2026',
+    });
+  });
+});

--- a/src/utils/mergeProgress.js
+++ b/src/utils/mergeProgress.js
@@ -1,0 +1,176 @@
+const PROGRESS_FIELDS = {
+  progress: {},
+  earnedBadges: {},
+  totalExperience: 0,
+  userTitle: '新手探索者',
+  studyStreak: 0,
+  lastStudyDate: null,
+  quizScores: {},
+  firstActivityTimestamp: null,
+};
+
+export class ProgressImportError extends Error {
+  constructor(code, message = code) {
+    super(message);
+    this.name = 'ProgressImportError';
+    this.code = code;
+  }
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function pickObject(value) {
+  return isPlainObject(value) ? value : {};
+}
+
+function pickNumber(value, fallback = 0) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function pickTimestamp(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function pickString(value, fallback = null) {
+  return typeof value === 'string' && value.length > 0 ? value : fallback;
+}
+
+function newerDateString(a, b) {
+  const aTime = Date.parse(a || '');
+  const bTime = Date.parse(b || '');
+
+  if (Number.isNaN(aTime)) return pickString(b, null);
+  if (Number.isNaN(bTime)) return pickString(a, null);
+  return bTime > aTime ? b : a;
+}
+
+function mergeBadges(existing = {}, incoming = {}) {
+  const merged = { ...existing };
+
+  Object.entries(incoming).forEach(([badgeId, badge]) => {
+    const current = merged[badgeId];
+    const currentTimestamp = pickNumber(current?.timestamp, 0);
+    const incomingTimestamp = pickNumber(badge?.timestamp, 0);
+
+    if (!current || incomingTimestamp >= currentTimestamp) {
+      merged[badgeId] = badge;
+    }
+  });
+
+  return merged;
+}
+
+function quizScoreRank(score) {
+  if (!score) return [-1, -1, 0];
+  const total = pickNumber(score.total, 0);
+  const rawScore = pickNumber(score.score, 0);
+  const ratio = total > 0 ? rawScore / total : 0;
+  return [score.isPerfect ? 1 : 0, ratio, rawScore];
+}
+
+function isBetterQuizScore(candidate, current) {
+  const candidateRank = quizScoreRank(candidate);
+  const currentRank = quizScoreRank(current);
+
+  for (let i = 0; i < candidateRank.length; i += 1) {
+    if (candidateRank[i] > currentRank[i]) return true;
+    if (candidateRank[i] < currentRank[i]) return false;
+  }
+  return false;
+}
+
+function mergeQuizScores(existing = {}, incoming = {}) {
+  const merged = { ...existing };
+
+  Object.entries(incoming).forEach(([lessonId, score]) => {
+    if (!merged[lessonId] || isBetterQuizScore(score, merged[lessonId])) {
+      merged[lessonId] = score;
+    }
+  });
+
+  return merged;
+}
+
+export function normalizeProgressData(data = {}) {
+  return {
+    progress: pickObject(data.progress),
+    earnedBadges: pickObject(data.earnedBadges),
+    totalExperience: pickNumber(data.totalExperience),
+    userTitle: pickString(data.userTitle, PROGRESS_FIELDS.userTitle),
+    studyStreak: pickNumber(data.studyStreak),
+    lastStudyDate: pickString(data.lastStudyDate, null),
+    quizScores: pickObject(data.quizScores),
+    firstActivityTimestamp: pickTimestamp(data.firstActivityTimestamp),
+  };
+}
+
+export function isProgressDataEmpty(data = {}) {
+  const normalized = normalizeProgressData(data);
+
+  return (
+    Object.keys(normalized.progress).length === 0 &&
+    Object.keys(normalized.earnedBadges).length === 0 &&
+    Object.keys(normalized.quizScores).length === 0 &&
+    normalized.totalExperience === 0 &&
+    normalized.studyStreak === 0 &&
+    !normalized.lastStudyDate &&
+    !normalized.firstActivityTimestamp
+  );
+}
+
+export function mergeProgress(existing = {}, incoming = {}) {
+  const normalizedExisting = normalizeProgressData(existing);
+  const normalizedIncoming = normalizeProgressData(incoming);
+
+  if (isProgressDataEmpty(normalizedIncoming)) return normalizedExisting;
+  if (isProgressDataEmpty(normalizedExisting)) return normalizedIncoming;
+
+  const incomingHasHigherExperience =
+    normalizedIncoming.totalExperience > normalizedExisting.totalExperience;
+
+  return {
+    progress: {
+      ...normalizedExisting.progress,
+      ...normalizedIncoming.progress,
+    },
+    earnedBadges: mergeBadges(normalizedExisting.earnedBadges, normalizedIncoming.earnedBadges),
+    totalExperience: Math.max(
+      normalizedExisting.totalExperience,
+      normalizedIncoming.totalExperience
+    ),
+    userTitle: incomingHasHigherExperience
+      ? normalizedIncoming.userTitle
+      : normalizedExisting.userTitle,
+    studyStreak: Math.max(normalizedExisting.studyStreak, normalizedIncoming.studyStreak),
+    lastStudyDate: newerDateString(
+      normalizedExisting.lastStudyDate,
+      normalizedIncoming.lastStudyDate
+    ),
+    quizScores: mergeQuizScores(normalizedExisting.quizScores, normalizedIncoming.quizScores),
+    firstActivityTimestamp:
+      normalizedExisting.firstActivityTimestamp && normalizedIncoming.firstActivityTimestamp
+        ? Math.min(
+            normalizedExisting.firstActivityTimestamp,
+            normalizedIncoming.firstActivityTimestamp
+          )
+        : normalizedExisting.firstActivityTimestamp || normalizedIncoming.firstActivityTimestamp,
+  };
+}
+
+export function parseProgressImportPayload(payload) {
+  if (!isPlainObject(payload)) {
+    throw new ProgressImportError('invalid-json');
+  }
+
+  if (payload.version !== 1) {
+    throw new ProgressImportError('unsupported-version');
+  }
+
+  if (!isPlainObject(payload.data)) {
+    throw new ProgressImportError('invalid-json');
+  }
+
+  return normalizeProgressData(payload.data);
+}


### PR DESCRIPTION
## Summary
- Add Dashboard import flow for `.json` progress snapshots.
- Validate versioned export payloads, show inline errors for invalid JSON / unsupported versions, and import directly when local progress is empty.
- Add Replace / Merge / Cancel modal for existing local progress, backed by tested merge rules.
- Update AGENTS.md with progress import/export schema notes.

Closes #95

## Verification
- `npm test` — 26 files / 166 tests passed.
- `npm run lint` — ESLint passed with max warnings 0.
- `npm run ai:verify` — source/public AI artifacts, MCP manifest, llms.txt, bilingual coverage, and x402 metadata passed.
- `npm run build` — production build passed; prerender completed 131/131 routes.
- Playwright smoke against local Dashboard: export download + import merge round-trip passed.