### PR TITLE
docs: add 10 Web3 glossary entries

### DIFF
--- a/ai/content-index.json
+++ b/ai/content-index.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2026-05-09",
-  "generatedAt": "2026-05-15T02:01:48.287Z",
+  "generatedAt": "2026-05-15T03:30:03.705Z",
   "repository": {
     "name": "Get-Started-with-Web3",
     "owner": "beihaili",
@@ -17797,6 +17797,116 @@
       "term": "Restaking",
       "definition": "将已质押资产或流动性质押代币再次用于保护其他网络或服务，以换取额外收益并承担额外风险。",
       "category": "DeFi",
+      "citation": {
+        "file": "src/config/glossaryData.js",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/src/config/glossaryData.js",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/zh/glossary"
+      }
+    },
+    {
+      "type": "glossary",
+      "term": "EIP-4844 (Proto-Danksharding / 原型分片)",
+      "definition": "以太坊 Dencun 升级引入的 Blob 交易方案，为 Rollup 提供成本更低的临时数据可用性空间。",
+      "category": "Layer 2",
+      "citation": {
+        "file": "src/config/glossaryData.js",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/src/config/glossaryData.js",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/zh/glossary"
+      }
+    },
+    {
+      "type": "glossary",
+      "term": "隐身地址 (Stealth Address)",
+      "definition": "为每次收款生成一次性地址的隐私技术，让外部观察者更难把多笔收款关联到同一接收者。",
+      "category": "安全",
+      "citation": {
+        "file": "src/config/glossaryData.js",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/src/config/glossaryData.js",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/zh/glossary"
+      }
+    },
+    {
+      "type": "glossary",
+      "term": "Rollup（汇总扩容）",
+      "definition": "把大量交易在链下执行或聚合，再把结果和必要数据提交到 L1 的扩容方案；不同于侧链，它通常继承 L1 的部分安全性。",
+      "category": "Layer 2",
+      "citation": {
+        "file": "src/config/glossaryData.js",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/src/config/glossaryData.js",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/zh/glossary"
+      }
+    },
+    {
+      "type": "glossary",
+      "term": "侧链 (Sidechain)",
+      "definition": "与主链并行运行、拥有独立共识和验证者集合的区块链，可扩展应用空间但安全性不直接等同于主链。",
+      "category": "Layer 2",
+      "citation": {
+        "file": "src/config/glossaryData.js",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/src/config/glossaryData.js",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/zh/glossary"
+      }
+    },
+    {
+      "type": "glossary",
+      "term": "流动性质押代币 (Liquid Staking Token, LST)",
+      "definition": "代表已质押资产及其收益权的可转让代币，例如 stETH 或 rETH；它提升资金效率，也会引入脱锚和罚没风险。",
+      "category": "DeFi",
+      "citation": {
+        "file": "src/config/glossaryData.js",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/src/config/glossaryData.js",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/zh/glossary"
+      }
+    },
+    {
+      "type": "glossary",
+      "term": "空投农场 (Airdrop Farming)",
+      "definition": "为了提高未来空投资格而系统性使用协议、跨链、交易或完成任务的行为，可能带来女巫过滤、成本和安全风险。",
+      "category": "DeFi",
+      "citation": {
+        "file": "src/config/glossaryData.js",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/src/config/glossaryData.js",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/zh/glossary"
+      }
+    },
+    {
+      "type": "glossary",
+      "term": "求解器 (Solver)",
+      "definition": "在 Intent 或批量拍卖系统中寻找最优执行路径的参与者，常负责撮合订单、路由流动性和提交结算交易。",
+      "category": "DeFi",
+      "citation": {
+        "file": "src/config/glossaryData.js",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/src/config/glossaryData.js",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/zh/glossary"
+      }
+    },
+    {
+      "type": "glossary",
+      "term": "罚没 (Slashing)",
+      "definition": "权益证明网络对验证者违规、离线或双签等行为扣除质押资产的惩罚机制，用来约束验证者诚实参与。",
+      "category": "以太坊",
+      "citation": {
+        "file": "src/config/glossaryData.js",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/src/config/glossaryData.js",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/zh/glossary"
+      }
+    },
+    {
+      "type": "glossary",
+      "term": "跨链桥 (Bridge)",
+      "definition": "连接不同区块链或 L2 的协议，用于转移资产或消息；桥的信任模型差异很大，是常见安全风险点。",
+      "category": "Layer 2",
+      "citation": {
+        "file": "src/config/glossaryData.js",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/src/config/glossaryData.js",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/zh/glossary"
+      }
+    },
+    {
+      "type": "glossary",
+      "term": "预言机 (Oracle)",
+      "definition": "把链下价格、事件或随机数等外部数据提供给智能合约的系统，解决合约无法直接读取链外信息的问题。",
+      "category": "工具",
       "citation": {
         "file": "src/config/glossaryData.js",
         "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/src/config/glossaryData.js",

--- a/ai/llms.txt
+++ b/ai/llms.txt
@@ -4,7 +4,7 @@ This repository exposes bilingual Web3 learning content for AI agents.
 
 Source: https://github.com/beihaili/Get-Started-with-Web3
 Homepage: https://beihaili.github.io/Get-Started-with-Web3/
-Generated: 2026-05-15T02:01:48.287Z
+Generated: 2026-05-15T03:30:03.705Z
 
 ## Artifacts
 - Manifest: ai/manifest.json

--- a/ai/manifest.json
+++ b/ai/manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2026-05-09",
-  "generatedAt": "2026-05-15T02:01:48.287Z",
+  "generatedAt": "2026-05-15T03:30:03.705Z",
   "repository": {
     "name": "Get-Started-with-Web3",
     "owner": "beihaili",
@@ -15,7 +15,7 @@
   "counts": {
     "modules": 11,
     "lessons": 106,
-    "glossaryEntries": 45,
+    "glossaryEntries": 55,
     "tools": 8,
     "futurePaidTools": 2
   },

--- a/public/ai/content-index.json
+++ b/public/ai/content-index.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2026-05-09",
-  "generatedAt": "2026-05-15T02:01:48.287Z",
+  "generatedAt": "2026-05-15T03:30:03.705Z",
   "repository": {
     "name": "Get-Started-with-Web3",
     "owner": "beihaili",
@@ -17797,6 +17797,116 @@
       "term": "Restaking",
       "definition": "将已质押资产或流动性质押代币再次用于保护其他网络或服务，以换取额外收益并承担额外风险。",
       "category": "DeFi",
+      "citation": {
+        "file": "src/config/glossaryData.js",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/src/config/glossaryData.js",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/zh/glossary"
+      }
+    },
+    {
+      "type": "glossary",
+      "term": "EIP-4844 (Proto-Danksharding / 原型分片)",
+      "definition": "以太坊 Dencun 升级引入的 Blob 交易方案，为 Rollup 提供成本更低的临时数据可用性空间。",
+      "category": "Layer 2",
+      "citation": {
+        "file": "src/config/glossaryData.js",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/src/config/glossaryData.js",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/zh/glossary"
+      }
+    },
+    {
+      "type": "glossary",
+      "term": "隐身地址 (Stealth Address)",
+      "definition": "为每次收款生成一次性地址的隐私技术，让外部观察者更难把多笔收款关联到同一接收者。",
+      "category": "安全",
+      "citation": {
+        "file": "src/config/glossaryData.js",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/src/config/glossaryData.js",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/zh/glossary"
+      }
+    },
+    {
+      "type": "glossary",
+      "term": "Rollup（汇总扩容）",
+      "definition": "把大量交易在链下执行或聚合，再把结果和必要数据提交到 L1 的扩容方案；不同于侧链，它通常继承 L1 的部分安全性。",
+      "category": "Layer 2",
+      "citation": {
+        "file": "src/config/glossaryData.js",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/src/config/glossaryData.js",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/zh/glossary"
+      }
+    },
+    {
+      "type": "glossary",
+      "term": "侧链 (Sidechain)",
+      "definition": "与主链并行运行、拥有独立共识和验证者集合的区块链，可扩展应用空间但安全性不直接等同于主链。",
+      "category": "Layer 2",
+      "citation": {
+        "file": "src/config/glossaryData.js",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/src/config/glossaryData.js",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/zh/glossary"
+      }
+    },
+    {
+      "type": "glossary",
+      "term": "流动性质押代币 (Liquid Staking Token, LST)",
+      "definition": "代表已质押资产及其收益权的可转让代币，例如 stETH 或 rETH；它提升资金效率，也会引入脱锚和罚没风险。",
+      "category": "DeFi",
+      "citation": {
+        "file": "src/config/glossaryData.js",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/src/config/glossaryData.js",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/zh/glossary"
+      }
+    },
+    {
+      "type": "glossary",
+      "term": "空投农场 (Airdrop Farming)",
+      "definition": "为了提高未来空投资格而系统性使用协议、跨链、交易或完成任务的行为，可能带来女巫过滤、成本和安全风险。",
+      "category": "DeFi",
+      "citation": {
+        "file": "src/config/glossaryData.js",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/src/config/glossaryData.js",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/zh/glossary"
+      }
+    },
+    {
+      "type": "glossary",
+      "term": "求解器 (Solver)",
+      "definition": "在 Intent 或批量拍卖系统中寻找最优执行路径的参与者，常负责撮合订单、路由流动性和提交结算交易。",
+      "category": "DeFi",
+      "citation": {
+        "file": "src/config/glossaryData.js",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/src/config/glossaryData.js",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/zh/glossary"
+      }
+    },
+    {
+      "type": "glossary",
+      "term": "罚没 (Slashing)",
+      "definition": "权益证明网络对验证者违规、离线或双签等行为扣除质押资产的惩罚机制，用来约束验证者诚实参与。",
+      "category": "以太坊",
+      "citation": {
+        "file": "src/config/glossaryData.js",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/src/config/glossaryData.js",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/zh/glossary"
+      }
+    },
+    {
+      "type": "glossary",
+      "term": "跨链桥 (Bridge)",
+      "definition": "连接不同区块链或 L2 的协议，用于转移资产或消息；桥的信任模型差异很大，是常见安全风险点。",
+      "category": "Layer 2",
+      "citation": {
+        "file": "src/config/glossaryData.js",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/src/config/glossaryData.js",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/zh/glossary"
+      }
+    },
+    {
+      "type": "glossary",
+      "term": "预言机 (Oracle)",
+      "definition": "把链下价格、事件或随机数等外部数据提供给智能合约的系统，解决合约无法直接读取链外信息的问题。",
+      "category": "工具",
       "citation": {
         "file": "src/config/glossaryData.js",
         "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/src/config/glossaryData.js",

--- a/public/ai/manifest.json
+++ b/public/ai/manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2026-05-09",
-  "generatedAt": "2026-05-15T02:01:48.287Z",
+  "generatedAt": "2026-05-15T03:30:03.705Z",
   "repository": {
     "name": "Get-Started-with-Web3",
     "owner": "beihaili",
@@ -15,7 +15,7 @@
   "counts": {
     "modules": 11,
     "lessons": 106,
-    "glossaryEntries": 45,
+    "glossaryEntries": 55,
     "tools": 8,
     "futurePaidTools": 2
   },

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -4,7 +4,7 @@ This repository exposes bilingual Web3 learning content for AI agents.
 
 Source: https://github.com/beihaili/Get-Started-with-Web3
 Homepage: https://beihaili.github.io/Get-Started-with-Web3/
-Generated: 2026-05-15T02:01:48.287Z
+Generated: 2026-05-15T03:30:03.705Z
 
 ## Artifacts
 - Manifest: ai/manifest.json

--- a/src/config/__tests__/glossaryData.test.js
+++ b/src/config/__tests__/glossaryData.test.js
@@ -1,6 +1,68 @@
 import { describe, it, expect } from 'vitest';
 import { GLOSSARY_DATA } from '../glossaryData';
 
+const plannedExpansionTerms = [
+  {
+    term: 'EIP-4844',
+    englishQuery: 'proto-danksharding',
+    chineseQuery: '临时数据',
+  },
+  {
+    term: 'Stealth Address',
+    englishQuery: 'stealth',
+    chineseQuery: '隐身地址',
+  },
+  {
+    term: 'Rollup',
+    englishQuery: 'rollup',
+    chineseQuery: '侧链',
+  },
+  {
+    term: 'Sidechain',
+    englishQuery: 'sidechain',
+    chineseQuery: '独立共识',
+  },
+  {
+    term: 'LST',
+    englishQuery: 'liquid staking',
+    chineseQuery: '流动性质押',
+  },
+  {
+    term: 'Airdrop Farming',
+    englishQuery: 'airdrop',
+    chineseQuery: '空投农场',
+  },
+  {
+    term: 'Solver',
+    englishQuery: 'solver',
+    chineseQuery: '求解器',
+  },
+  {
+    term: 'Slashing',
+    englishQuery: 'slashing',
+    chineseQuery: '罚没',
+  },
+  {
+    term: 'Bridge',
+    englishQuery: 'bridge',
+    chineseQuery: '跨链桥',
+  },
+  {
+    term: 'Oracle',
+    englishQuery: 'oracle',
+    chineseQuery: '预言机',
+  },
+];
+
+const findByQuery = (query) => {
+  const normalizedQuery = query.toLowerCase();
+  return GLOSSARY_DATA.filter(
+    (item) =>
+      item.term.toLowerCase().includes(normalizedQuery) ||
+      item.definition.toLowerCase().includes(normalizedQuery)
+  );
+};
+
 describe('glossaryData', () => {
   it('should have at least 40 terms', () => {
     expect(GLOSSARY_DATA.length).toBeGreaterThanOrEqual(40);
@@ -40,5 +102,18 @@ describe('glossaryData', () => {
     expect(categories).toContain('Layer 2');
     expect(categories).toContain('稳定币');
     expect(categories).toContain('安全');
+  });
+
+  it('includes the planned Web3 glossary expansion terms', () => {
+    plannedExpansionTerms.forEach(({ term }) => {
+      expect(GLOSSARY_DATA.some((item) => item.term.includes(term))).toBe(true);
+    });
+  });
+
+  it('finds each planned expansion term by English and Chinese keywords', () => {
+    plannedExpansionTerms.forEach(({ term, englishQuery, chineseQuery }) => {
+      expect(findByQuery(englishQuery).some((item) => item.term.includes(term))).toBe(true);
+      expect(findByQuery(chineseQuery).some((item) => item.term.includes(term))).toBe(true);
+    });
   });
 });

--- a/src/config/glossaryData.js
+++ b/src/config/glossaryData.js
@@ -239,6 +239,65 @@ export const GLOSSARY_DATA = [
       '将已质押资产或流动性质押代币再次用于保护其他网络或服务，以换取额外收益并承担额外风险。',
     category: 'DeFi',
   },
+  {
+    term: 'EIP-4844 (Proto-Danksharding / 原型分片)',
+    definition:
+      '以太坊 Dencun 升级引入的 Blob 交易方案，为 Rollup 提供成本更低的临时数据可用性空间。',
+    category: 'Layer 2',
+  },
+  {
+    term: '隐身地址 (Stealth Address)',
+    definition: '为每次收款生成一次性地址的隐私技术，让外部观察者更难把多笔收款关联到同一接收者。',
+    category: '安全',
+  },
+  {
+    term: 'Rollup（汇总扩容）',
+    definition:
+      '把大量交易在链下执行或聚合，再把结果和必要数据提交到 L1 的扩容方案；不同于侧链，它通常继承 L1 的部分安全性。',
+    category: 'Layer 2',
+  },
+  {
+    term: '侧链 (Sidechain)',
+    definition:
+      '与主链并行运行、拥有独立共识和验证者集合的区块链，可扩展应用空间但安全性不直接等同于主链。',
+    category: 'Layer 2',
+  },
+  {
+    term: '流动性质押代币 (Liquid Staking Token, LST)',
+    definition:
+      '代表已质押资产及其收益权的可转让代币，例如 stETH 或 rETH；它提升资金效率，也会引入脱锚和罚没风险。',
+    category: 'DeFi',
+  },
+  {
+    term: '空投农场 (Airdrop Farming)',
+    definition:
+      '为了提高未来空投资格而系统性使用协议、跨链、交易或完成任务的行为，可能带来女巫过滤、成本和安全风险。',
+    category: 'DeFi',
+  },
+  {
+    term: '求解器 (Solver)',
+    definition:
+      '在 Intent 或批量拍卖系统中寻找最优执行路径的参与者，常负责撮合订单、路由流动性和提交结算交易。',
+    category: 'DeFi',
+  },
+  {
+    term: '罚没 (Slashing)',
+    definition:
+      '权益证明网络对验证者违规、离线或双签等行为扣除质押资产的惩罚机制，用来约束验证者诚实参与。',
+    category: '以太坊',
+  },
+  {
+    term: '跨链桥 (Bridge)',
+    definition:
+      '连接不同区块链或 L2 的协议，用于转移资产或消息；桥的信任模型差异很大，是常见安全风险点。',
+    category: 'Layer 2',
+  },
+  {
+    term: '预言机 (Oracle)',
+    definition:
+      '把链下价格、事件或随机数等外部数据提供给智能合约的系统，解决合约无法直接读取链外信息的问题。',
+    category: '工具',
+  },
 ];
 
 export const GLOSSARY_CATEGORIES = [


### PR DESCRIPTION
## Summary
- Add 10 non-duplicate Web3 glossary entries: EIP-4844, stealth addresses, Rollup, sidechains, LSTs, airdrop farming, solvers, slashing, bridges, and oracles.
- Add glossary data tests that assert the new terms exist and can be found by English and Chinese keywords through the same search logic used by the glossary page.
- Regenerate AI-native glossary artifacts so `ai/content-index.json` and public artifacts expose 55 glossary entries.

Closes #88

## Verification
- RED: `npx vitest run src/config/__tests__/glossaryData.test.js` failed before the new entries were added.
- `npx prettier --check src/config/glossaryData.js src/config/__tests__/glossaryData.test.js`
- `npx vitest run src/config/__tests__/glossaryData.test.js`
- `npm test` — 26 files / 168 tests passed.
- `npm run lint` — ESLint passed with max warnings 0.
- `npm run ai:verify` — AI artifacts and metadata passed.
- `npm run build` — production build passed; prerender completed 131/131 routes.
- `git diff --check`
- `rg` against `dist/assets/GlossaryPage-*.js` confirmed the built glossary bundle includes the new entries.