### PR TITLE
perf: lazy load lesson images with dimensions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ npm run mcp:web3        # 启动本地 stdio MCP server
 - `scripts/generate-ai-index.mjs`: 生成上述 artifact。
 - `scripts/publish-ai-artifacts.mjs`: 将根目录 `ai/` artifacts 复制到 `public/`。
 - `scripts/verify-ai-entrypoints.mjs`: 检查 artifacts、公开 URL、MCP 工具清单、中英文覆盖和 x402 元数据。
+- `scripts/sync-content.mjs`: 将中英文课程内容复制到 `public/content/`，并生成 `public/content/image-metadata.json`，供课程图片渲染时补充 `width` / `height`。
 - `scripts/check-translation-coverage.mjs`: 非阻塞检查 `zh/` 中缺失的英文翻译，支持 `README.md` 和 `README.MD` 两种文件名。
 - `scripts/ai-content-core.mjs`: 搜索、读取课程、生成学习路径、组合上下文等纯函数。
 

--- a/scripts/__tests__/sync-content.test.js
+++ b/scripts/__tests__/sync-content.test.js
@@ -1,4 +1,5 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { Buffer } from 'node:buffer';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -86,4 +87,42 @@ describe('sync-content', () => {
       )
     ).resolves.toContain('English');
   });
+
+  it('writes image dimension metadata for copied lesson images', async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'web3-sync-content-'));
+    const lessonDir = path.join(tempDir, 'zh', 'EthereumSmartAccounts', '01_EthereumAfterPectra');
+    await mkdir(path.join(lessonDir, 'img'), { recursive: true });
+    await writeFile(path.join(lessonDir, 'README.md'), '# 中文\n', 'utf8');
+    await writeFile(path.join(lessonDir, 'img', 'diagram.png'), createPngHeader(640, 360));
+
+    await syncContent({
+      projectRoot: tempDir,
+      courseData: [
+        {
+          lessons: [{ path: 'EthereumSmartAccounts/01_EthereumAfterPectra' }],
+        },
+      ],
+      logger: { log() {}, warn() {}, error() {} },
+    });
+
+    const metadata = JSON.parse(
+      await readFile(path.join(tempDir, 'public', 'content', 'image-metadata.json'), 'utf8')
+    );
+
+    expect(metadata['zh/EthereumSmartAccounts/01_EthereumAfterPectra/img/diagram.png']).toEqual({
+      width: 640,
+      height: 360,
+    });
+  });
 });
+
+const createPngHeader = (width, height) => {
+  const buffer = Buffer.alloc(24);
+  buffer.writeUInt8(0x89, 0);
+  buffer.write('PNG\r\n\u001a\n', 1, 'binary');
+  buffer.writeUInt32BE(13, 8);
+  buffer.write('IHDR', 12, 'ascii');
+  buffer.writeUInt32BE(width, 16);
+  buffer.writeUInt32BE(height, 20);
+  return buffer;
+};

--- a/scripts/sync-content.mjs
+++ b/scripts/sync-content.mjs
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { cp, mkdir, rm, stat } from 'node:fs/promises';
+import { cp, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { COURSE_DATA } from '../src/config/courseData.js';
@@ -10,6 +10,125 @@ const projectRoot = path.resolve(__dirname, '..');
 
 const ensureExists = async (dir) => {
   await mkdir(dir, { recursive: true });
+};
+
+const IMAGE_EXTENSIONS = new Set(['.gif', '.jpeg', '.jpg', '.png']);
+const IMAGE_METADATA_FILE = 'image-metadata.json';
+
+const isImageFile = (filePath) => IMAGE_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+
+const readPngDimensions = (buffer) => {
+  const pngSignature = '89504e470d0a1a0a';
+  if (buffer.length < 24 || buffer.subarray(0, 8).toString('hex') !== pngSignature) {
+    return null;
+  }
+
+  return {
+    width: buffer.readUInt32BE(16),
+    height: buffer.readUInt32BE(20),
+  };
+};
+
+const readGifDimensions = (buffer) => {
+  if (buffer.length < 10 || !['GIF87a', 'GIF89a'].includes(buffer.subarray(0, 6).toString())) {
+    return null;
+  }
+
+  return {
+    width: buffer.readUInt16LE(6),
+    height: buffer.readUInt16LE(8),
+  };
+};
+
+const readJpegDimensions = (buffer) => {
+  if (buffer.length < 4 || buffer[0] !== 0xff || buffer[1] !== 0xd8) {
+    return null;
+  }
+
+  let offset = 2;
+  const startOfFrameMarkers = new Set([
+    0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf,
+  ]);
+
+  while (offset < buffer.length) {
+    while (buffer[offset] === 0xff) {
+      offset += 1;
+    }
+
+    const marker = buffer[offset];
+    offset += 1;
+
+    if (marker === 0xd9 || marker === 0xda) {
+      break;
+    }
+
+    if (offset + 2 > buffer.length) {
+      break;
+    }
+
+    const segmentLength = buffer.readUInt16BE(offset);
+    if (segmentLength < 2 || offset + segmentLength > buffer.length) {
+      break;
+    }
+
+    if (startOfFrameMarkers.has(marker)) {
+      return {
+        width: buffer.readUInt16BE(offset + 5),
+        height: buffer.readUInt16BE(offset + 3),
+      };
+    }
+
+    offset += segmentLength;
+  }
+
+  return null;
+};
+
+export const readImageDimensions = async (filePath) => {
+  const buffer = await readFile(filePath);
+  return readPngDimensions(buffer) || readJpegDimensions(buffer) || readGifDimensions(buffer);
+};
+
+export const collectImageMetadata = async (contentRoot) => {
+  const metadata = {};
+
+  const visit = async (dir) => {
+    const entries = await readdir(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const entryPath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        await visit(entryPath);
+        continue;
+      }
+
+      if (!entry.isFile() || entry.name === IMAGE_METADATA_FILE || !isImageFile(entryPath)) {
+        continue;
+      }
+
+      const dimensions = await readImageDimensions(entryPath);
+      if (!dimensions) {
+        continue;
+      }
+
+      const relativePath = path.relative(contentRoot, entryPath).split(path.sep).join('/');
+      metadata[relativePath] = dimensions;
+    }
+  };
+
+  await visit(contentRoot);
+  return metadata;
+};
+
+const writeImageMetadata = async (contentRoot, logger = console) => {
+  const metadata = await collectImageMetadata(contentRoot);
+  await writeFile(
+    path.join(contentRoot, IMAGE_METADATA_FILE),
+    `${JSON.stringify(metadata, null, 2)}\n`,
+    'utf8'
+  );
+  logger.log(`[sync-content] Wrote ${Object.keys(metadata).length} image metadata entries`);
 };
 
 export const getSourceFoldersFromCourseData = (courseData = COURSE_DATA) => {
@@ -59,11 +178,12 @@ export const syncContent = async (options = {}) => {
   const sourceFolders = options.sourceFolders || getSourceFoldersFromCourseData(options.courseData);
   const logger = options.logger || console;
 
-  await ensureExists(path.join(root, 'public', 'content'));
+  const contentRoot = path.join(root, 'public', 'content');
+  await ensureExists(contentRoot);
 
   for (const folder of sourceFolders) {
     const src = path.join(root, 'zh', folder);
-    const dest = path.join(root, 'public', 'content', 'zh', folder);
+    const dest = path.join(contentRoot, 'zh', folder);
     await safeCopy(src, dest, logger);
   }
 
@@ -78,6 +198,8 @@ export const syncContent = async (options = {}) => {
       await safeCopy(src, dest, logger);
     }
   }
+
+  await writeImageMetadata(contentRoot, logger);
 
   logger.log(
     `[sync-content] Completed. Content root: ${path.relative(root, path.join(root, 'public', 'content', 'zh'))}`

--- a/src/features/content/components/MarkdownRenderer.jsx
+++ b/src/features/content/components/MarkdownRenderer.jsx
@@ -32,7 +32,24 @@ const CopyButton = ({ text }) => {
   );
 };
 
-const MarkdownRendererInner = ({ content, basePath = '' }) => {
+const mergeClassNames = (...classNames) => classNames.filter(Boolean).join(' ');
+
+const normalizeImageMetadataKey = (src, imageMetadataBase) => {
+  if (!src || src.startsWith('http') || src.startsWith('/')) {
+    return null;
+  }
+
+  const cleanSrc = src.split('#')[0].split('?')[0].replace(/^\.\//, '');
+  const cleanBase = imageMetadataBase.replace(/^\/+|\/+$/g, '');
+  return [cleanBase, cleanSrc].filter(Boolean).join('/');
+};
+
+const MarkdownRendererInner = ({
+  content,
+  basePath = '',
+  imageMetadata = {},
+  imageMetadataBase = '',
+}) => {
   const components = useMemo(() => {
     // 处理图片路径
     const resolveImageSrc = (src) => {
@@ -96,17 +113,40 @@ const MarkdownRendererInner = ({ content, basePath = '' }) => {
       ),
 
       // 图片
-      img: ({ src, alt, width }) => (
-        <span className="inline-flex m-1 align-middle">
-          <img
-            src={resolveImageSrc(src)}
-            alt={alt || 'Image'}
-            loading="lazy"
-            className="rounded-lg max-w-full h-auto shadow-lg"
-            style={{ maxHeight: '500px', width: width ? `${width}px` : 'auto' }}
-          />
-        </span>
-      ),
+      img: ({
+        src,
+        alt,
+        width,
+        height,
+        className,
+        loading,
+        decoding,
+        style,
+        node: _node,
+        ...props
+      }) => {
+        const metadataKey = normalizeImageMetadataKey(src, imageMetadataBase);
+        const dimensions = metadataKey ? imageMetadata[metadataKey] : null;
+        const imageWidth = width || dimensions?.width;
+        const imageHeight = height || dimensions?.height;
+        const imageStyle = style && typeof style === 'object' ? style : {};
+
+        return (
+          <span className="inline-flex m-1 align-middle">
+            <img
+              {...props}
+              src={resolveImageSrc(src)}
+              alt={alt || 'Image'}
+              loading={loading || 'lazy'}
+              decoding={decoding || 'async'}
+              width={imageWidth || undefined}
+              height={imageHeight || undefined}
+              className={mergeClassNames('rounded-lg max-w-full h-auto shadow-lg', className)}
+              style={{ maxHeight: '500px', ...imageStyle }}
+            />
+          </span>
+        );
+      },
 
       // 粗体
       strong: ({ children }) => <strong className="text-white font-bold">{children}</strong>,
@@ -219,7 +259,7 @@ const MarkdownRendererInner = ({ content, basePath = '' }) => {
       // 分隔
       br: () => <br />,
     };
-  }, [basePath]);
+  }, [basePath, imageMetadata, imageMetadataBase]);
 
   return (
     <div className="font-sans text-base markdown-content">

--- a/src/features/content/components/__tests__/MarkdownRenderer.test.jsx
+++ b/src/features/content/components/__tests__/MarkdownRenderer.test.jsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import MarkdownRenderer from '../MarkdownRenderer';
+
+describe('MarkdownRenderer images', () => {
+  it('renders lesson images with lazy loading, async decoding, dimensions, and preserved attributes', () => {
+    render(
+      <MarkdownRenderer
+        basePath="/Get-Started-with-Web3/en/GetStartedWithBitcoin/03_BitcoinTx/"
+        content={
+          '<img src="./img/tx.png" alt="Transaction structure" class="lesson-diagram" width="640" height="360" />'
+        }
+      />
+    );
+
+    const image = screen.getByRole('img', { name: 'Transaction structure' });
+
+    expect(image).toHaveAttribute(
+      'src',
+      '/Get-Started-with-Web3/en/GetStartedWithBitcoin/03_BitcoinTx/img/tx.png'
+    );
+    expect(image).toHaveAttribute('loading', 'lazy');
+    expect(image).toHaveAttribute('decoding', 'async');
+    expect(image).toHaveAttribute('width', '640');
+    expect(image).toHaveAttribute('height', '360');
+    expect(image).toHaveClass('lesson-diagram');
+    expect(image).toHaveClass('rounded-lg');
+  });
+
+  it('uses image metadata to add dimensions to markdown images without inline attrs', () => {
+    render(
+      <MarkdownRenderer
+        basePath="/Get-Started-with-Web3/content/en/GetStartedWithBitcoin/03_BitcoinTx/"
+        imageMetadataBase="en/GetStartedWithBitcoin/03_BitcoinTx/"
+        imageMetadata={{
+          'en/GetStartedWithBitcoin/03_BitcoinTx/img/tx.png': {
+            width: 1280,
+            height: 720,
+          },
+        }}
+        content="![Transaction chain](./img/tx.png)"
+      />
+    );
+
+    const image = screen.getByRole('img', { name: 'Transaction chain' });
+
+    expect(image).toHaveAttribute(
+      'src',
+      '/Get-Started-with-Web3/content/en/GetStartedWithBitcoin/03_BitcoinTx/img/tx.png'
+    );
+    expect(image).toHaveAttribute('width', '1280');
+    expect(image).toHaveAttribute('height', '720');
+    expect(image).toHaveAttribute('loading', 'lazy');
+    expect(image).toHaveAttribute('decoding', 'async');
+  });
+});

--- a/src/pages/ReaderPage.jsx
+++ b/src/pages/ReaderPage.jsx
@@ -28,12 +28,14 @@ const ReaderPage = () => {
   const { t } = useTranslation();
   const { markLessonComplete, getLessonProgress, recordQuizScore, checkModuleBadges } =
     useUserStore();
-  const { fetchLessonContent } = useContentStore();
+  const { fetchLessonContent, basePath: publicBasePath } = useContentStore();
 
   const [content, setContent] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [basePath, setBasePath] = useState('');
+  const [imageMetadata, setImageMetadata] = useState({});
+  const [imageMetadataBase, setImageMetadataBase] = useState('');
   const [showShareCard, setShowShareCard] = useState(false);
 
   const lessonKey = `${moduleId}-${lessonId}`;
@@ -59,20 +61,29 @@ const ReaderPage = () => {
         setContent(lessonContent || currentLesson.fallbackContent || t('reader.loadingFallback'));
 
         // 设置图片基础路径 (includes lang prefix for correct asset resolution)
-        const pathParts = currentLesson.path.split('/');
-        const base = pathParts.slice(0, -1).join('/') + '/';
-        setBasePath(`/Get-Started-with-Web3/${lang}/${base}`);
+        const base = `${currentLesson.path.replace(/\/+$/, '')}/`;
+        setBasePath(`${publicBasePath}content/${lang}/${base}`);
+        setImageMetadataBase(`${lang}/${base}`);
+
+        try {
+          const metadataResponse = await fetch(`${publicBasePath}content/image-metadata.json`);
+          setImageMetadata(metadataResponse.ok ? await metadataResponse.json() : {});
+        } catch (metadataError) {
+          console.warn('Failed to load image metadata:', metadataError);
+          setImageMetadata({});
+        }
       } catch (err) {
         console.error('Failed to load lesson:', err);
         setError(err.message);
         setContent(currentLesson.fallbackContent || t('reader.loadFailedFallback'));
+        setImageMetadata({});
       } finally {
         setLoading(false);
       }
     };
 
     loadContent();
-  }, [lang, moduleId, lessonId, currentLesson, fetchLessonContent, t]);
+  }, [lang, moduleId, lessonId, currentLesson, fetchLessonContent, publicBasePath, t]);
 
   const handleMarkComplete = (score, total) => {
     if (score !== undefined && total !== undefined) {
@@ -241,7 +252,12 @@ const ReaderPage = () => {
 
               {/* Markdown Content */}
               <div className="prose dark:prose-invert max-w-none">
-                <MarkdownRenderer content={content} basePath={basePath} />
+                <MarkdownRenderer
+                  content={content}
+                  basePath={basePath}
+                  imageMetadata={imageMetadata}
+                  imageMetadataBase={imageMetadataBase}
+                />
               </div>
 
               {/* Quiz Section */}

--- a/src/store/__tests__/useContentStore.test.js
+++ b/src/store/__tests__/useContentStore.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useContentStore } from '../useContentStore';
 
 beforeEach(() => {
@@ -7,6 +7,70 @@ beforeEach(() => {
     pendingFetches: {},
     contentLoading: false,
     fetchError: null,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('fetchLessonContent', () => {
+  it('falls back to GitHub raw content when the local markdown request returns SPA HTML', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response('<!doctype html><html><head></head><body>SPA fallback</body></html>', {
+          status: 200,
+          headers: { 'Content-Type': 'text/html' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response('Not Found', {
+          status: 404,
+          headers: { 'Content-Type': 'text/plain' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response('# Lesson Markdown', {
+          status: 200,
+          headers: { 'Content-Type': 'text/plain' },
+        })
+      );
+
+    const content = await useContentStore
+      .getState()
+      .fetchLessonContent('zh', 'GetStartedWithBitcoin/03_BitcoinTx');
+
+    expect(content).toBe('# Lesson Markdown');
+    expect(fetch).toHaveBeenNthCalledWith(
+      3,
+      'https://raw.githubusercontent.com/beihaili/Get-Started-with-Web3/main/zh/GetStartedWithBitcoin/03_BitcoinTx/README.md'
+    );
+  });
+
+  it('tries uppercase README.MD before falling back to GitHub raw content', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response('<!doctype html><html><head></head><body>SPA fallback</body></html>', {
+          status: 200,
+          headers: { 'Content-Type': 'text/html' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response('# Local Uppercase Markdown', {
+          status: 200,
+          headers: { 'Content-Type': 'text/plain' },
+        })
+      );
+
+    const content = await useContentStore
+      .getState()
+      .fetchLessonContent('zh', 'GetStartedWithBitcoin/03_BitcoinTx');
+
+    expect(content).toBe('# Local Uppercase Markdown');
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      '/Get-Started-with-Web3/content/zh/GetStartedWithBitcoin/03_BitcoinTx/README.MD'
+    );
   });
 });
 

--- a/src/store/useContentStore.js
+++ b/src/store/useContentStore.js
@@ -9,6 +9,18 @@ import { create } from 'zustand';
  */
 const MAX_CACHE_ENTRIES = 50;
 
+const looksLikeHtmlDocument = (content) => {
+  const normalized = content.trimStart().toLowerCase();
+  return normalized.startsWith('<!doctype html') || normalized.startsWith('<html');
+};
+
+const getLessonContentUrls = (basePath, lang, lessonPath) => [
+  `${basePath}content/${lang}/${lessonPath}/README.md`,
+  `${basePath}content/${lang}/${lessonPath}/README.MD`,
+  `https://raw.githubusercontent.com/beihaili/Get-Started-with-Web3/main/${lang}/${lessonPath}/README.md`,
+  `https://raw.githubusercontent.com/beihaili/Get-Started-with-Web3/main/${lang}/${lessonPath}/README.MD`,
+];
+
 export const useContentStore = create((set, get) => ({
   // 当前选中的模块和课程
   activeModule: null,
@@ -63,21 +75,29 @@ export const useContentStore = create((set, get) => ({
       set({ contentLoading: true, fetchError: null });
 
       try {
-        // 尝试从本地public目录加载
-        const localUrl = `${get().basePath}content/${lang}/${lessonPath}/README.md`;
-        let response = await fetch(localUrl);
+        let content = null;
+        let lastStatus = 'unknown';
 
-        // 如果本地加载失败，尝试从GitHub Raw加载
-        if (!response.ok) {
-          const githubUrl = `https://raw.githubusercontent.com/beihaili/Get-Started-with-Web3/main/${lang}/${lessonPath}/README.md`;
-          response = await fetch(githubUrl);
+        for (const url of getLessonContentUrls(get().basePath, lang, lessonPath)) {
+          const response = await fetch(url);
+          lastStatus = response.status;
+
+          if (!response.ok) {
+            continue;
+          }
+
+          const responseText = await response.text();
+          if (looksLikeHtmlDocument(responseText)) {
+            continue;
+          }
+
+          content = responseText;
+          break;
         }
 
-        if (!response.ok) {
-          throw new Error(`Failed to fetch content: ${response.status}`);
+        if (content === null) {
+          throw new Error(`Failed to fetch content: ${lastStatus}`);
         }
-
-        const content = await response.text();
 
         // 缓存内容（带上限淘汰）
         const currentCache = { ...get().contentCache };


### PR DESCRIPTION
## Summary
- Preserve Markdown image attrs/classes while forcing lazy loading and async decoding in `MarkdownRenderer`.
- Generate `public/content/image-metadata.json` during `sync-content` and use it to add `width` / `height` for local lesson images.
- Fix reader image/content resolution for `README.MD` lessons and full lesson-relative image paths, so local and production pages do not treat SPA fallback HTML as Markdown.
- Document the new image metadata contract in AGENTS.md.

Closes #92

## Long-lesson image check
- Before/current production `zh/learn/module-2/2-3`: content failed with `Failed to fetch content: 404`, so long-lesson images did not render and LCP comparison was not meaningful.
- After local fix on the same route: 6 lesson images rendered; local PNG images returned `200 image/png` with preserved alt text plus `loading=\"lazy\"`, `decoding=\"async\"`, `width`, and `height`.
- `sync-content` generated 53 local image metadata entries.

## Verification
- RED: `npx vitest run src/features/content/components/__tests__/MarkdownRenderer.test.jsx` failed before metadata dimensions were implemented.
- RED: `npx vitest run scripts/__tests__/sync-content.test.js` failed before `image-metadata.json` generation existed.
- RED: `npx vitest run src/store/__tests__/useContentStore.test.js` failed before SPA fallback / `README.MD` handling.
- `npx vitest run scripts/__tests__/sync-content.test.js src/features/content/components/__tests__/MarkdownRenderer.test.jsx src/store/__tests__/useContentStore.test.js`
- `npm test` — 27 files / 173 tests passed.
- `npm run lint`
- `npm run ai:verify`
- `npm run build` — production build passed; prerender completed 131/131 routes.
- `git diff --check`
- Playwright smoke against local `zh/learn/module-2/2-3` verified image attrs and successful local image responses.