### PR TITLE
feat: add localized DeFi DEX quiz

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,12 @@ npm run mcp:web3        # 启动本地 stdio MCP server
 - `src/utils/progressExport.js`: 导出 schema 与浏览器下载逻辑，当前 payload 为 `{ version, exportedAt, data }`，`data` 只包含 `useUserStore` 中的非敏感学习进度字段。
 - `src/utils/mergeProgress.js`: 导入 schema 校验、进度归一化和纯合并逻辑；合并规则需保持可测试，避免在 UI 组件里写业务合并逻辑。
 
+## 测验题库
+
+- `src/features/quiz/quizData.js`: 每个 lesson id 对应 5 道选择题；顶层 `question`、`options`、`explanation` 是中文默认内容。
+- `src/features/quiz/MultiQuiz.jsx`: 渲染时会按当前 i18n 语言读取可选 `translations.<lang>` 字段；缺失时回退到顶层中文内容。新增英文题面时优先补 `translations.en.question`、`translations.en.options` 和 `translations.en.explanation`，不要改变 `lessonId` / `onPass` 接口。
+- `src/features/quiz/__tests__/quizData.test.js`: 维护题库结构、题数、重复题和重点课程本地化断言。新增 quiz 数据结构约定时先补测试。
+
 ## MCP Server
 
 `scripts/web3-mcp-server.mjs` 使用官方 `@modelcontextprotocol/sdk` 暴露本地 stdio MCP server。该 server 是只读的，不应写文件、修改课程内容或执行链上操作。

--- a/src/features/quiz/MultiQuiz.jsx
+++ b/src/features/quiz/MultiQuiz.jsx
@@ -3,12 +3,31 @@ import { useTranslation } from 'react-i18next';
 import { BrainCircuit, CheckCircle, X } from 'lucide-react';
 import { QUIZ_BANK } from './quizData';
 
+function getLocalizedQuestion(question, language) {
+  const lang = language?.split('-')[0];
+  const localized = question.translations?.[lang];
+
+  if (!localized) {
+    return question;
+  }
+
+  return {
+    ...question,
+    question: localized.question || question.question,
+    options:
+      Array.isArray(localized.options) && localized.options.length === question.options.length
+        ? localized.options
+        : question.options,
+    explanation: localized.explanation || question.explanation,
+  };
+}
+
 /**
  * 3道题全对通关测验系统
  * 从原App.jsx迁移 (lines 1973-2325)
  */
 const MultiQuiz = ({ lessonId, onPass }) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [quizState, setQuizState] = useState('idle'); // idle, active, completed
   const [currentQuestion, setCurrentQuestion] = useState(0);
   const [answers, setAnswers] = useState([]);
@@ -96,7 +115,7 @@ const MultiQuiz = ({ lessonId, onPass }) => {
   }
 
   if (quizState === 'active') {
-    const currentQ = currentQuiz[currentQuestion];
+    const currentQ = getLocalizedQuestion(currentQuiz[currentQuestion], i18n.language);
 
     return (
       <div className="space-y-6">

--- a/src/features/quiz/__tests__/MultiQuiz.test.jsx
+++ b/src/features/quiz/__tests__/MultiQuiz.test.jsx
@@ -1,0 +1,20 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import MultiQuiz from '../MultiQuiz';
+import i18n from '../../../i18n';
+
+describe('MultiQuiz localization', () => {
+  afterEach(async () => {
+    await i18n.changeLanguage('zh');
+  });
+
+  it('renders English question copy when the current language is English', async () => {
+    await i18n.changeLanguage('en');
+
+    render(<MultiQuiz lessonId="8-2" onPass={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /Start Challenge/i }));
+
+    expect(screen.getByText(/What does AMM stand for/i)).toBeInTheDocument();
+    expect(screen.getByText(/Automated Market Maker/i)).toBeInTheDocument();
+  });
+});

--- a/src/features/quiz/__tests__/quizData.test.js
+++ b/src/features/quiz/__tests__/quizData.test.js
@@ -50,6 +50,33 @@ describe('Quiz data structure', () => {
     expect(QUIZ_BANK.default).toBeDefined();
     expect(QUIZ_BANK.default.length).toBe(5);
   });
+
+  it('DeFi DEX quiz has English copy for every question', () => {
+    const dexQuiz = QUIZ_BANK['8-2'];
+
+    for (const question of dexQuiz) {
+      expect(question.translations?.en).toEqual({
+        question: expect.any(String),
+        options: expect.any(Array),
+        explanation: expect.any(String),
+      });
+      expect(question.translations.en.question.length).toBeGreaterThan(0);
+      expect(question.translations.en.options).toHaveLength(4);
+      expect(question.translations.en.explanation.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('DeFi DEX quiz covers AMM invariant, slippage, and impermanent loss scenario', () => {
+    const dexQuiz = QUIZ_BANK['8-2'];
+    const firstQuestion = `${dexQuiz[0].question} ${dexQuiz[0].translations?.en?.question ?? ''}`;
+    const allCopy = JSON.stringify(dexQuiz);
+
+    expect(firstQuestion).toMatch(/AMM/);
+    expect(firstQuestion).toMatch(/x\s*[·*]\s*y\s*=\s*k/i);
+    expect(allCopy).toMatch(/滑点|slippage/i);
+    expect(allCopy).toMatch(/无常损失|impermanent loss/i);
+    expect(allCopy).toMatch(/相对持有|holding/i);
+  });
 });
 
 describe('Quiz data uniqueness', () => {

--- a/src/features/quiz/quizData.js
+++ b/src/features/quiz/quizData.js
@@ -2339,34 +2339,29 @@ export const QUIZ_BANK = {
   ],
   '8-2': [
     {
-      question: 'Uniswap 使用的恒定乘积做市商公式是什么？',
-      options: ['x + y = k', 'x * y = k', 'x / y = k', 'x ^ y = k'],
-      correctAnswer: 1,
-      explanation:
-        'Uniswap 使用恒定乘积公式 x * y = k，其中 x 和 y 分别是池中两种代币的数量，k 是常数。',
-    },
-    {
-      question: '在 AMM 中，"无常损失"（Impermanent Loss）是什么？',
+      question: 'AMM（自动做市商）的含义和 x · y = k 恒定乘积公式说明了什么？',
       options: [
-        '由于手续费导致的交易损失',
-        '相比简单持有代币，将其放入流动性池可能导致的价值损失',
-        '由于 Gas 费波动导致的损失',
-        '因为代币价格下跌造成的投资损失',
+        'AMM 通过订单簿撮合买卖双方，x · y = k 表示交易所利润固定',
+        'AMM 是 Automated Market Maker，池中两种资产数量乘积在交易后保持为常数 k',
+        'AMM 是账户管理模块，x · y = k 表示 Gas 费上限',
+        'AMM 只适用于中心化交易所，x · y = k 表示用户数量不变',
       ],
       correctAnswer: 1,
       explanation:
-        '无常损失是指相比 HODL 两种代币，将它们放入 AMM 流动性池可能导致的价值差异。价格偏离越大，无常损失越大。',
-    },
-    {
-      question: 'Uniswap V3 相比 V2 的最大创新是什么？',
-      options: [
-        '支持更多代币种类',
-        '集中流动性——LP 可以选择在特定价格区间提供流动性',
-        '完全去除手续费',
-        '引入订单簿模式',
-      ],
-      correctAnswer: 1,
-      explanation: 'V3 允许 LP 选择提供流动性的价格区间（集中流动性），大幅提升了资本效率。',
+        'AMM 是 Automated Market Maker（自动做市商）。在恒定乘积模型中，x 和 y 分别是池中两种资产数量，交易会改变比例，但会让 x · y 维持在同一个常数 k 附近。',
+      translations: {
+        en: {
+          question: 'What does AMM stand for, and what does the x · y = k invariant mean?',
+          options: [
+            'AMM matches buyers and sellers with an order book, and x · y = k means exchange profit is fixed',
+            'AMM means Automated Market Maker, and the product of the two pool reserves stays constant after trades',
+            'AMM means Account Management Module, and x · y = k means the gas limit is fixed',
+            'AMM only applies to centralized exchanges, and x · y = k means user count is constant',
+          ],
+          explanation:
+            'AMM stands for Automated Market Maker. In the constant product model, x and y are the two asset reserves, and trades change their ratio while keeping x · y near the constant k.',
+        },
+      },
     },
     {
       question: '为什么大额交易在 AMM 中会产生较大的滑点？',
@@ -2378,7 +2373,70 @@ export const QUIZ_BANK = {
       ],
       correctAnswer: 1,
       explanation:
-        '在 AMM 中，交易金额占池子的比例越大，对池中代币比例的改变越大，导致实际成交价格偏离预期价格越多。',
+        '在 AMM 中，交易金额占池子的比例越大，对池中代币比例的改变越大，实际成交价格就越偏离交易前看到的价格。',
+      translations: {
+        en: {
+          question: 'What causes larger slippage in an AMM trade?',
+          options: [
+            'Trading fees always rise linearly with trade size',
+            'A large trade changes the pool reserve ratio more, so the execution price moves farther from the quoted price',
+            'Validators charge a special fee for large trades',
+            'Large trades always need more block confirmations',
+          ],
+          explanation:
+            'Slippage grows when the trade is large relative to pool depth. The swap moves the reserve ratio, so the average execution price differs from the pre-trade quote.',
+        },
+      },
+    },
+    {
+      question: 'ETH/USDC 池中 ETH 大幅上涨时，LP 相比简单持有更容易在哪一侧吃亏？',
+      options: [
+        'LP 会持有更少上涨的 ETH、更多 USDC，错过部分 ETH 上涨收益',
+        'LP 会自动持有更多上涨的 ETH，因此没有无常损失',
+        'LP 的损失只来自 Gas 费，与价格变化无关',
+        'LP Token 会被销毁，导致本金全部归零',
+      ],
+      correctAnswer: 0,
+      explanation:
+        '当 ETH 相对 USDC 上涨时，套利交易会让池子卖出 ETH、买入 USDC。LP 最终持有更少的上涨资产，可能跑输相对持有初始 ETH+USDC 的组合。',
+      translations: {
+        en: {
+          question:
+            'If ETH rises sharply in an ETH/USDC pool, where does impermanent loss usually come from for the LP?',
+          options: [
+            'The LP ends up with less of the rising ETH and more USDC, missing part of the ETH upside versus holding',
+            'The LP automatically holds more of the rising ETH, so impermanent loss cannot happen',
+            'The loss only comes from gas fees and has nothing to do with price movement',
+            'The LP token is burned, making the principal go to zero',
+          ],
+          explanation:
+            'When ETH rises against USDC, arbitrage rebalances the pool by removing ETH and adding USDC. The LP can underperform simply holding the starting ETH and USDC mix because they hold less of the asset that rose.',
+        },
+      },
+    },
+    {
+      question: 'Uniswap V3 相比 V2 的最大创新是什么？',
+      options: [
+        '支持更多代币种类',
+        '集中流动性——LP 可以选择在特定价格区间提供流动性',
+        '完全去除手续费',
+        '引入订单簿模式',
+      ],
+      correctAnswer: 1,
+      explanation: 'V3 允许 LP 选择提供流动性的价格区间（集中流动性），大幅提升了资本效率。',
+      translations: {
+        en: {
+          question: 'What is Uniswap V3’s biggest innovation compared with V2?',
+          options: [
+            'It supports more token symbols',
+            'Concentrated liquidity, where LPs choose the price ranges where their capital is active',
+            'It removes trading fees entirely',
+            'It replaces AMMs with an order book',
+          ],
+          explanation:
+            'Uniswap V3 introduced concentrated liquidity. LPs can allocate capital to specific price ranges, which can improve capital efficiency but also requires more active risk management.',
+        },
+      },
     },
     {
       question: 'LP Token 代表什么？',
@@ -2390,6 +2448,19 @@ export const QUIZ_BANK = {
       ],
       correctAnswer: 1,
       explanation: 'LP Token 是流动性提供者在池中的份额凭证，类似于基金份额。',
+      translations: {
+        en: {
+          question: 'What does an LP token represent?',
+          options: [
+            'A governance token',
+            'A receipt for a liquidity provider’s share of the pool',
+            'A receipt for one trade’s fee',
+            'An exchange membership pass',
+          ],
+          explanation:
+            'An LP token represents the liquidity provider’s claim on their share of the pool, similar to a fund share.',
+        },
+      },
     },
   ],
   '8-3': [


### PR DESCRIPTION
## Summary
- Adds English-localized copy for the DeFi AMM/DEX quiz while keeping Chinese as the default fallback.
- Updates the DEX quiz to cover AMM meaning + x · y = k, slippage, and an impermanent-loss scenario.
- Adds component/data tests for localized quiz rendering and documents the quiz translation convention in AGENTS.md.

Closes #89

## Validation
- npm test
- npm run lint
- npm run build
- npm run ai:verify
- Playwright smoke: /en/learn/module-8/8-2 renders the English AMM quiz question after clicking Start Challenge