### PR TITLE
docs: add daily operations reports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@
 - `docs/strategy/2026-05-14-awesome-list-submissions.md`: awesome-list 和社区分发追踪，包含定位文案、目标列表、PR 模板和中文社区帖草案。
 - `docs/community/contributor-ladder.md`: 贡献者成长路径，定义 first-time contributor、repeat contributor、reviewer、module steward 和 community/sponsor ally。
 - `docs/community/good-first-issues.md`: 可复制到 GitHub Issues 的 starter issue 清单，包含标签、背景、验收标准和验证方式。
+- `docs/operations/`: 每日运营汇报目录；`README.md` 定义 cadence、数据源和风险边界，`templates/daily-report-template.md` 是每日汇报模板，按 `YYYY-MM-DD-daily-report.md` 记录实际进展、指标、部署、外部分发、赞助线索和下一步。
 
 社区入口：
 

--- a/docs/operations/2026-05-15-daily-report.md
+++ b/docs/operations/2026-05-15-daily-report.md
@@ -1,0 +1,74 @@
+# Get Started with Web3 Daily Operations Report
+
+**Date:** 2026-05-15
+**Owner:** beihai + Codex
+**Reporting window:** 2026-05-15 operating block; GitHub timestamps below are UTC unless noted.
+
+## KPI Snapshot
+
+| Metric | Current | Previous / Baseline | Movement | Source |
+| --- | ---: | ---: | ---: | --- |
+| GitHub stars | 614 | 614 short-term baseline | 0 | `gh repo view beihaili/Get-Started-with-Web3` |
+| Forks | 55 | 55 | 0 | `gh repo view beihaili/Get-Started-with-Web3` |
+| Watchers | 3 | 3 | 0 | `gh repo view beihaili/Get-Started-with-Web3` |
+| Open internal PRs | 0 | 0 | 0 | `gh pr list --state open` after #135 merge |
+| Open issues | 14 | 15 before #89 closure | -1 | `gh issue list --state open --limit 20` |
+
+## Completed
+
+- Content: merged [#135](https://github.com/beihaili/Get-Started-with-Web3/pull/135), adding English-localized DeFi DEX quiz copy and stronger AMM, slippage, and impermanent-loss coverage. Closed [#89](https://github.com/beihaili/Get-Started-with-Web3/issues/89).
+- Platform performance: merged [#134](https://github.com/beihaili/Get-Started-with-Web3/pull/134), adding lesson-image lazy loading and generated image dimensions. Closed [#92](https://github.com/beihaili/Get-Started-with-Web3/issues/92).
+- Content depth: merged [#133](https://github.com/beihaili/Get-Started-with-Web3/pull/133), expanding the Web3 glossary.
+- Learner retention: merged [#131](https://github.com/beihaili/Get-Started-with-Web3/pull/131) and [#132](https://github.com/beihaili/Get-Started-with-Web3/pull/132), adding progress export/import flows.
+- Trust and safety: merged [#130](https://github.com/beihaili/Get-Started-with-Web3/pull/130), adding wallet safety warnings.
+- Source credibility: merged [#129](https://github.com/beihaili/Get-Started-with-Web3/pull/129), adding DeFi core concept source links.
+- Distribution assets: merged [#128](https://github.com/beihaili/Get-Started-with-Web3/pull/128), drafting public community distribution posts.
+
+## Deploy And Verification
+
+| Surface | Status | Evidence | Notes |
+| --- | --- | --- | --- |
+| Latest production deploy | Success | [Run 25904061676](https://github.com/beihaili/Get-Started-with-Web3/actions/runs/25904061676) | `feat: add localized DeFi DEX quiz (#135)` completed on main |
+| PR checks for latest shipment | Success | [#135](https://github.com/beihaili/Get-Started-with-Web3/pull/135) | Deploy and Lighthouse checks passed before merge |
+| Local tests for #135 | Success | `npm test`: 28 files, 176 tests | Ran before PR and again after commit |
+| Local lint for #135 | Success | `npm run lint` | No ESLint output |
+| Local build for #135 | Success | `npm run build` | Prerendered 131/131 routes |
+| AI entrypoints | Success | `npm run ai:verify` | Source/public artifacts, MCP tools, `llms.txt`, and x402 metadata verified |
+| Production smoke | Success | `https://beihaili.github.io/Get-Started-with-Web3/en/learn/module-8/8-2/` | English AMM quiz question rendered; no console or page errors |
+
+## External Distribution
+
+| Target | Status | Evidence | Next action |
+| --- | --- | --- | --- |
+| TensorBlock `awesome-mcp-servers` | Open, waiting re-review | [PR #544](https://github.com/TensorBlock/awesome-mcp-servers/pull/544) | Reviewer requested matching docs entry; update was posted on 2026-05-15 01:02:45 UTC. Monitor for review response before further nudging. |
+| Public post queue | Drafted, not yet published | `docs/strategy/2026-05-15-public-post-drafts.md` | Publish one low-risk post after external PR is no longer blocked or after next content improvement lands. |
+
+## Sponsor And Revenue
+
+| Lead / Channel | Status | Next action | Risk notes |
+| --- | --- | --- | --- |
+| Wallet projects | Drafted outreach only | Identify 3 specific wallet/security projects with strong beginner-education fit | Avoid accepting sponsorship that asks for unsafe wallet recommendations |
+| RPC / infrastructure providers | Drafted outreach only | Shortlist providers relevant to builder labs and MCP/agent workflows | Keep MCP server read-only; do not imply paid x402 tools are live |
+| L2 ecosystems | Drafted outreach only | Match sponsorship ask to L2/bridge learning modules | Avoid chain-promotion claims that weaken educational neutrality |
+| Exchanges / affiliate | Policy review needed | Review donation and affiliate disclosures before outreach | High trust risk; require explicit confirmation before accepting sensitive sponsorship |
+
+## Blockers And Risks
+
+- Stars did not move yet: current count remains 614, so distribution and public-post execution remain the main growth bottleneck.
+- External PR #544 is still `CHANGES_REQUESTED/BLOCKED` even though the requested update was posted. This needs monitoring, not repeated comments yet.
+- Translation/proofreading issues remain open for modules 2, 4, and 5-6; English content quality is still a conversion risk for global learners.
+- Sponsor lead tracker has categories but no named leads or outreach log yet.
+
+## Next Operating Block
+
+1. Pick one growth-facing product issue: [#93](https://github.com/beihaili/Get-Started-with-Web3/issues/93) for i18n payload performance or [#87](https://github.com/beihaili/Get-Started-with-Web3/issues/87) for mobile reader UX.
+2. Monitor [TensorBlock/awesome-mcp-servers#544](https://github.com/TensorBlock/awesome-mcp-servers/pull/544); if no reviewer response after a reasonable window, leave one concise follow-up.
+3. Convert sponsor tracker categories into named leads, starting with low-risk wallet/security and infrastructure projects.
+
+## Evidence Links
+
+- Main repository: https://github.com/beihaili/Get-Started-with-Web3
+- Latest production site: https://beihaili.github.io/Get-Started-with-Web3/
+- Latest merged PR: https://github.com/beihaili/Get-Started-with-Web3/pull/135
+- Latest main deploy: https://github.com/beihaili/Get-Started-with-Web3/actions/runs/25904061676
+- External MCP list PR: https://github.com/TensorBlock/awesome-mcp-servers/pull/544

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,0 +1,33 @@
+# Operations Reports
+
+This folder is the durable operating log for Get Started with Web3.
+
+Use it to keep growth, content, community, distribution, AI-native, sponsorship, and technical-health work visible after each operating day. Strategy docs define the plan; operations reports record what actually happened.
+
+## Cadence
+
+- Create one report per active operating day.
+- File name: `YYYY-MM-DD-daily-report.md`.
+- Use `templates/daily-report-template.md` for the structure.
+- Prefer recording evidence links over memory: PRs, issues, workflow runs, public URLs, and external submissions.
+
+## Required Sources
+
+Each report should refresh:
+
+- GitHub repo metrics: stars, forks, watchers, open PRs, and current topics if changed.
+- Recent merged PRs and closed issues.
+- Latest production deploy status.
+- External distribution status, including awesome-list PRs and community posts.
+- AI-native status: `llms.txt`, AI manifest, content index, MCP, and verification notes when touched.
+- Monetization and sponsor lead movement.
+- Next 1-3 actions for the next operating block.
+
+## Risk Boundaries
+
+Record, but do not execute without explicit confirmation:
+
+- Changing donation or payment addresses.
+- Accepting sensitive finance/trading sponsors.
+- Private repository, ownership transfer, deletion, or secret-handling actions.
+- Any action that bypasses tests, security checks, or protected deployment flow.

--- a/docs/operations/templates/daily-report-template.md
+++ b/docs/operations/templates/daily-report-template.md
@@ -1,0 +1,60 @@
+# Get Started with Web3 Daily Operations Report
+
+**Date:** YYYY-MM-DD
+**Owner:** beihai + Codex
+**Reporting window:** Describe timezone and data capture time.
+
+## KPI Snapshot
+
+| Metric | Current | Previous / Baseline | Movement | Source |
+| --- | ---: | ---: | ---: | --- |
+| GitHub stars | TBD | TBD | TBD | `gh repo view` |
+| Forks | TBD | TBD | TBD | `gh repo view` |
+| Watchers | TBD | TBD | TBD | `gh repo view` |
+| Open PRs | TBD | TBD | TBD | `gh pr list` |
+| Open issues | TBD | TBD | TBD | `gh issue list` |
+
+## Completed
+
+- Content:
+- Platform:
+- Community:
+- External distribution:
+- AI-native:
+- Monetization:
+
+## Deploy And Verification
+
+| Surface | Status | Evidence | Notes |
+| --- | --- | --- | --- |
+| Production deploy | TBD | Link | |
+| Tests | TBD | Command / run | |
+| Lint | TBD | Command / run | |
+| AI entrypoints | TBD | Command / run | |
+| Smoke test | TBD | URL / result | |
+
+## External Distribution
+
+| Target | Status | Evidence | Next action |
+| --- | --- | --- | --- |
+| Awesome MCP servers | TBD | Link | |
+
+## Sponsor And Revenue
+
+| Lead / Channel | Status | Next action | Risk notes |
+| --- | --- | --- | --- |
+| TBD | TBD | TBD | TBD |
+
+## Blockers And Risks
+
+- TBD
+
+## Next Operating Block
+
+1. TBD
+2. TBD
+3. TBD
+
+## Evidence Links
+
+- TBD

--- a/docs/strategy/2026-05-14-execution-board.md
+++ b/docs/strategy/2026-05-14-execution-board.md
@@ -142,6 +142,8 @@ Update weekly.
 
 ## Reporting Template
 
+Daily reports live in `docs/operations/` and use `docs/operations/templates/daily-report-template.md`.
+
 Daily report should include:
 
 - Completed since last report.


### PR DESCRIPTION
## Summary
- Adds `docs/operations/` as the durable daily operating log for growth, content, community, distribution, AI-native, sponsorship, and technical-health work.
- Adds a reusable daily report template and the first 2026-05-15 operations report with current metrics, shipped PRs, deploy evidence, external distribution status, sponsor lead notes, blockers, and next actions.
- Links the operations report system from AGENTS.md and the execution board.

## Validation
- npm test
- npm run lint
- git diff --check HEAD