### PR TITLE
[codex] Add sponsor lead tracker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 - `docs/strategy/2026-05-14-execution-board.md`: 执行看板，包含 KPI、工作流、前 10 个任务、内容发布队列和赞助线索。
 - `docs/strategy/2026-05-14-sponsor-kit.md`: 赞助包草案，包含受众、价格、曝光权益、接受政策和月度汇报指标。
 - `docs/strategy/2026-05-14-sponsor-outreach-drafts.md`: 赞助外联话术草案；常规外联可自主执行，高风险赞助对象仍需单独确认。
+- `docs/strategy/2026-05-15-sponsor-leads-tracker.md`: 具名赞助/资助线索 tracker，记录公开来源、fit score、建议外联角度、渠道、状态和风险边界；发送外联后必须同步每日运营汇报。
 - `docs/strategy/2026-05-14-awesome-list-submissions.md`: awesome-list 和社区分发追踪，包含定位文案、目标列表、PR 模板和中文社区帖草案。
 - `docs/community/contributor-ladder.md`: 贡献者成长路径，定义 first-time contributor、repeat contributor、reviewer、module steward 和 community/sponsor ally。
 - `docs/community/good-first-issues.md`: 可复制到 GitHub Issues 的 starter issue 清单，包含标签、背景、验收标准和验证方式。

--- a/docs/operations/2026-05-15-daily-report.md
+++ b/docs/operations/2026-05-15-daily-report.md
@@ -23,6 +23,7 @@
 - Trust and safety: merged [#130](https://github.com/beihaili/Get-Started-with-Web3/pull/130), adding wallet safety warnings.
 - Source credibility: merged [#129](https://github.com/beihaili/Get-Started-with-Web3/pull/129), adding DeFi core concept source links.
 - Distribution assets: merged [#128](https://github.com/beihaili/Get-Started-with-Web3/pull/128), drafting public community distribution posts.
+- Monetization operations: added `docs/strategy/2026-05-15-sponsor-leads-tracker.md` with named low-risk leads, public evidence, outreach order, risk notes, and a pre-outreach checklist.
 
 ## Deploy And Verification
 
@@ -47,9 +48,12 @@
 
 | Lead / Channel | Status | Next action | Risk notes |
 | --- | --- | --- | --- |
-| Wallet projects | Drafted outreach only | Identify 3 specific wallet/security projects with strong beginner-education fit | Avoid accepting sponsorship that asks for unsafe wallet recommendations |
-| RPC / infrastructure providers | Drafted outreach only | Shortlist providers relevant to builder labs and MCP/agent workflows | Keep MCP server read-only; do not imply paid x402 tools are live |
-| L2 ecosystems | Drafted outreach only | Match sponsorship ask to L2/bridge learning modules | Avoid chain-promotion claims that weaken educational neutrality |
+| Safe Ecosystem Foundation | Queued lead | Prepare grant-style impact memo for smart account and account abstraction education | Low trust risk; keep outputs educational and open-source |
+| Reown / WalletConnect | Queued lead | Personalize wallet UX and connection-safety outreach | Avoid implying endorsement of any specific wallet |
+| QuickNode | Queued lead | Personalize infrastructure sponsor outreach around builder labs and RPC lessons | Do not promise developer acquisition numbers yet |
+| Blockaid / Blowfish | Queued security leads | Pick one first security outreach to avoid overlapping asks | Keep security claims factual and tool-neutral |
+| Ethereum Foundation ESP | Researching | Package public-goods impact memo after more usage metrics | Grant path, not commercial sponsor |
+| L2 ecosystems | Researching | Match sponsorship ask to L2/bridge learning modules | Avoid chain-promotion claims that weaken educational neutrality |
 | Exchanges / affiliate | Policy review needed | Review donation and affiliate disclosures before outreach | High trust risk; require explicit confirmation before accepting sensitive sponsorship |
 
 ## Blockers And Risks
@@ -57,13 +61,13 @@
 - Stars did not move yet: current count remains 614, so distribution and public-post execution remain the main growth bottleneck.
 - External PR #544 is still `CHANGES_REQUESTED/BLOCKED` even though the requested update was posted. This needs monitoring, not repeated comments yet.
 - Translation/proofreading issues remain open for modules 2, 4, and 5-6; English content quality is still a conversion risk for global learners.
-- Sponsor lead tracker has categories but no named leads or outreach log yet.
+- Sponsor lead tracker now has named leads, but no outreach has been sent yet. First messages still need a current metrics refresh and exact channel selection.
 
 ## Next Operating Block
 
 1. Pick one growth-facing product issue: [#93](https://github.com/beihaili/Get-Started-with-Web3/issues/93) for i18n payload performance or [#87](https://github.com/beihaili/Get-Started-with-Web3/issues/87) for mobile reader UX.
 2. Monitor [TensorBlock/awesome-mcp-servers#544](https://github.com/TensorBlock/awesome-mcp-servers/pull/544); if no reviewer response after a reasonable window, leave one concise follow-up.
-3. Convert sponsor tracker categories into named leads, starting with low-risk wallet/security and infrastructure projects.
+3. Prepare first sponsor outreach packet for Safe, Reown, or QuickNode; send only after metrics and sponsor-kit link are refreshed.
 
 ## Evidence Links
 

--- a/docs/strategy/2026-05-14-execution-board.md
+++ b/docs/strategy/2026-05-14-execution-board.md
@@ -84,7 +84,7 @@ Update weekly.
 - [x] Add sponsor analytics snapshot section; initially use GitHub traffic and public repo metrics.
 - [x] Draft 3 sponsor outreach templates: wallet, infrastructure, exchange/affiliate.
 - [x] Draft sponsor acceptance policy.
-- [ ] Track sponsor leads in a simple Markdown table until volume justifies a CRM.
+- [x] Track sponsor leads in a simple Markdown table until volume justifies a CRM: `docs/strategy/2026-05-15-sponsor-leads-tracker.md`.
 - [ ] Review donation and affiliate disclosures.
 
 ### 6. Contributor Community
@@ -132,13 +132,16 @@ Update weekly.
 
 ## Sponsor Lead Tracker
 
-| Sponsor                      | Category           | Fit                                           | Status        | Next Action               |
-| ---------------------------- | ------------------ | --------------------------------------------- | ------------- | ------------------------- |
-| Wallet projects              | Wallet/security    | Beginner onboarding and wallet safety lessons | Not contacted | Draft outreach            |
-| RPC/infrastructure providers | Devtool            | Builder labs and Bitcoin RPC lessons          | Not contacted | Draft outreach            |
-| L2 ecosystems                | Chain/ecosystem    | L2 and bridge lessons                         | Not contacted | Draft outreach            |
-| Security audit tools         | Security           | Web3 safety and smart contract security       | Not contacted | Draft outreach            |
-| Exchanges                    | Exchange/affiliate | CEX onboarding and fiat on-ramp               | Not contacted | Review trust policy first |
+Detailed tracker: `docs/strategy/2026-05-15-sponsor-leads-tracker.md`.
+
+| Sponsor | Category | Fit | Status | Next Action |
+| --- | --- | --- | --- | --- |
+| Safe Ecosystem Foundation | Smart accounts / grants | Account abstraction, wallet recovery, security education | Queued | Prepare grant-style impact memo |
+| Reown / WalletConnect | Wallet UX / connectivity infra | Wallet connection safety and onboarding UX | Queued | Personalize wallet sponsor outreach |
+| QuickNode | RPC / infrastructure | Builder labs, RPC lessons, developer onboarding | Queued | Personalize infrastructure sponsor outreach |
+| Blockaid or Blowfish | Security tooling | Scam, approval, signing, and transaction-warning education | Queued | Pick one first security outreach |
+| Ethereum Foundation ESP | Public goods / grants | AI-native open-source Ethereum learning resources | Researching | Package public-goods impact memo |
+| Exchanges | Exchange / affiliate | CEX onboarding and fiat on-ramp | Hold | Requires explicit trust-policy review before contact |
 
 ## Reporting Template
 

--- a/docs/strategy/2026-05-14-sponsor-kit.md
+++ b/docs/strategy/2026-05-14-sponsor-kit.md
@@ -42,6 +42,7 @@ Notes:
 - Clone counts may include automated traffic and should not be treated as unique learners.
 - Public site analytics should be added to this kit once Cloudflare/GA data is reviewed.
 - Sponsor conversations should start after README positioning and SEO fixes are merged.
+- Named sponsor leads and outreach status are tracked in `docs/strategy/2026-05-15-sponsor-leads-tracker.md`.
 
 ## Sponsorship Tiers
 
@@ -151,5 +152,5 @@ Start with products that match the curriculum and have low trust risk:
 1. Merge SEO and README positioning fixes.
 2. Add a concise sponsor section to README if not already present.
 3. Add current sponsor kit link to support page after the copy is checked against sponsor safety rules.
-4. Prepare first outreach batch of 5 warm-fit targets.
+4. Done: prepare first outreach batch of warm-fit targets in `docs/strategy/2026-05-15-sponsor-leads-tracker.md`.
 5. Use the lowest-friction available channel for first outreach and record the action in the daily report.

--- a/docs/strategy/2026-05-15-sponsor-leads-tracker.md
+++ b/docs/strategy/2026-05-15-sponsor-leads-tracker.md
@@ -1,0 +1,66 @@
+# Sponsor Lead Tracker
+
+**Date:** 2026-05-15
+**Owner:** beihai + Codex
+**Status:** Internal tracker. No outreach has been sent from this file yet.
+
+This tracker turns the sponsor categories in the execution board into named, auditable leads. It is intentionally conservative: the first batch favors infrastructure, security, smart-account, education, and public-goods programs over exchanges, yield products, token launches, or trading campaigns.
+
+## Operating Rules
+
+- Record public evidence before outreach.
+- Use the existing sponsor kit and outreach drafts; personalize the first paragraph with the relevant lesson or product fit.
+- Log every sent message and reply in the daily operations report.
+- Do not promise traffic, conversions, exclusivity, lesson conclusions, token promotion, or investment outcomes.
+- Do not change payment details, accept funds, or publish a sponsor placement without explicit approval.
+- Escalate before contacting exchange, leverage, restaking, yield, launchpad, or trading-related leads.
+
+## Lead Scoring
+
+| Score | Meaning |
+| --- | --- |
+| 5 | Strong curriculum fit, low trust risk, obvious education or public-goods angle |
+| 4 | Good fit, low-to-medium risk, needs careful positioning |
+| 3 | Useful but indirect fit, better after more metrics or a specific campaign |
+| 2 | Possible fit but high diligence needed |
+| 1 | Do not contact in the current sponsor batch |
+
+## First Outreach Batch
+
+| Priority | Lead | Category | Fit score | Public evidence | Suggested angle | Channel | Status | Risk notes |
+| ---: | --- | --- | ---: | --- | --- | --- | --- | --- |
+| 1 | Safe Ecosystem Foundation | Smart accounts / security / grants | 5 | Safe funds smart-account infrastructure, security, developer tooling, research, ecosystem growth, and educational content through rolling grants: https://safefoundation.org/grants | Pitch a small educational grant or sponsor slot around smart accounts, wallet recovery, ERC-4337, and beginner-safe account abstraction. | Grant application | Queued | Low trust risk; keep outputs educational and open-source. |
+| 2 | Reown / WalletConnect | Wallet UX / connectivity infra | 5 | Reown is powered by WalletConnect and positions itself as secure, user-friendly infrastructure for onchain apps: https://reown.com/about-reown | Sponsor wallet-connectivity lessons and agent-readable onboarding material; position as UX infrastructure, not token promotion. | Contact sales / partnerships | Queued | Avoid implying endorsement of any specific wallet. |
+| 3 | QuickNode | RPC / infrastructure / developer education | 5 | QuickNode Startup Program includes credits, community, strategic collaborations, technical guidance, visibility, and Web3 knowledge: https://www.quicknode.com/startup | Infrastructure sponsor for builder labs, RPC lessons, and developer onboarding. | Startup program / partnerships | Queued | Good fit for builder content; do not promise developer acquisition numbers yet. |
+| 4 | Alchemy | Infrastructure / developer platform | 4 | Alchemy Ventures offers funding, platform access, architecture guidance, technical support, and developer distribution: https://www.alchemy.com/ventures-contact-funding | Explore education partnership or infrastructure support for AI-native Web3 curriculum and builder labs. | Ventures / partnerships | Queued | Their page is startup-oriented; frame as education/public-good partnership first. |
+| 5 | Blockaid | Web3 security | 4 | Blockaid presents itself as onchain security used by major Web3 companies and highlights MetaMask/Consensys security work: https://blockaid.io/ | Sponsor beginner safety content around malicious dApps, approvals, transaction simulation, and phishing defense. | Contact form / partnerships | Queued | Security claims must stay factual; avoid comparing competitors. |
+| 6 | Blowfish | Wallet security UX | 4 | Blowfish focuses on proactive defense for Web3 wallets and improving security UX: https://blowfish.xyz/ | Co-create or sponsor wallet-drainer, signing, and transaction-warning lessons. | Contact form | Queued | Similar to Blockaid; keep claims tool-neutral. |
+| 7 | Ethereum Foundation Ecosystem Support Program | Public goods / education / grants | 5 | ESP supports teams across the Ethereum ecosystem and coordinates grant management and funding: https://esp.ethereum.foundation/ | Apply for public-goods support after packaging AI-native curriculum impact, open-source outputs, and translation roadmap. | ESP inquiry / grant | Researching | Grant path, not commercial sponsor; stronger after public usage metrics improve. |
+| 8 | Optimism Collective / Atlas | L2 public goods / Superchain | 4 | Optimism describes Retro Funding and grants for builders creating measurable ecosystem value: https://www.optimism.io/collective | Position L2/cross-chain education, public-goods curriculum, and agent-readable learning resources for Superchain learners. | Atlas / grant path | Researching | Ecosystem-specific support must not bias lesson conclusions. |
+| 9 | Base Builder Grants | L2 builder ecosystem | 4 | Ethereum founder support lists Base Builder Grants as active, with 1-5 ETH grants for tooling and infrastructure: https://ethereum.org/founders/ | Apply after adding a stronger Base/L2 builder learning path or mini-app lab. | Grant path | Researching | Better after a Base-specific lesson or lab exists. |
+| 10 | Chainlink Community Grants | Oracle / developer education | 3 | Chainlink grant archive includes developer documentation, community-driven resources, and Chainlink Academy examples: https://go.chain.link/archives/community/grants | Consider after adding oracle, price feed, or cross-chain messaging curriculum content. | Grant / community program | Later | Needs new Chainlink-relevant content before outreach. |
+| 11 | Arbitrum Foundation | L2 ecosystem / grants | 3 | Arbitrum Foundation says it fosters ecosystem growth and links to grants: https://arbitrum.foundation/ | Consider for L2/cross-chain module support after improving Arbitrum-specific learning outcomes. | Grants | Later | Ecosystem-specific funding could bias L2 coverage; require neutral framing. |
+
+## Initial Outreach Order
+
+1. Safe Ecosystem Foundation: grant-style request, not paid ad placement.
+2. Reown / WalletConnect: wallet UX and connection safety.
+3. QuickNode: developer labs and RPC learning path.
+4. Blockaid or Blowfish: security education, choose one first to avoid overlapping asks.
+5. Ethereum Foundation ESP: public-goods support after packaging a stronger impact memo.
+
+## Pre-Outreach Checklist
+
+- [ ] Update sponsor kit metrics to the current star count and latest 14-day traffic before sending.
+- [ ] Add a stable public sponsor-kit link or attach the relevant section in the message.
+- [ ] Choose one clear ask: grant, sponsor slot, or educational collaboration.
+- [ ] Record the outreach date, channel, and exact message in the daily report.
+- [ ] Stop and ask for approval if the target requests paid placement, affiliate tracking, token promotion, financial claims, or changes to donation/payment details.
+
+## Outreach Log
+
+| Date | Lead | Channel | Message / Thread | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| TBD | Safe Ecosystem Foundation | Grant application | TBD | Not sent | Prepare impact memo first. |
+| TBD | Reown / WalletConnect | Contact sales / partnership | TBD | Not sent | Personalize around wallet UX and safe onboarding. |
+| TBD | QuickNode | Startup program / partnership | TBD | Not sent | Personalize around builder labs and RPC content. |


### PR DESCRIPTION
## Summary
- Add a named sponsor/grant lead tracker with public evidence, fit scoring, outreach order, channel/status fields, and risk boundaries.
- Update the sponsor kit, execution board, daily report, and AGENTS notes to point to the tracker.
- Keep all leads unsent and require metrics refresh plus daily-report logging before outreach.

## Validation
- npm test
- npm run lint
- git diff --check