### PR TITLE
[codex] Publish fallback lesson images

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ npm run mcp:web3        # 启动本地 stdio MCP server
 - `scripts/generate-ai-index.mjs`: 生成上述 artifact。
 - `scripts/publish-ai-artifacts.mjs`: 将根目录 `ai/` artifacts 复制到 `public/`。
 - `scripts/verify-ai-entrypoints.mjs`: 检查 artifacts、公开 URL、MCP 工具清单、中英文覆盖和 x402 元数据。
-- `scripts/sync-content.mjs`: 将中英文课程内容复制到 `public/content/`，并生成 `public/content/image-metadata.json`，供课程图片渲染时补充 `width` / `height`。
+- `scripts/sync-content.mjs`: 将中英文课程内容复制到 `public/content/`，为英文课程补齐对应中文课程中存在但英文目录缺失的本地图片资产，并生成 `public/content/image-metadata.json`，供课程图片渲染时补充 `width` / `height`。
 - `scripts/check-translation-coverage.mjs`: 非阻塞检查 `zh/` 中缺失的英文翻译，支持 `README.md` 和 `README.MD` 两种文件名。
 - `scripts/ai-content-core.mjs`: 搜索、读取课程、生成学习路径、组合上下文等纯函数。
 
@@ -130,6 +130,7 @@ Agent 使用 MCP 工具回答时，应优先引用工具返回的 `citation.file
 ## 修改注意
 
 - 新增或移动课程时，先更新 `src/config/courseData.js`，必要时同步 `src/features/badges/badgeData.js` 和 `zh/README.md`，再运行 `npm run ai:index`。
+- 英文课程 README 可以复用对应中文课程目录下的本地图片；`npm run sync-content` 会按 README 中的本地图片引用补齐缺失英文发布资产。若英文课程需要不同图片，直接放到 `en/` 对应目录，脚本不会覆盖已有英文图片。
 - 新增术语时，更新 `src/config/glossaryData.js` 和对应测试，保持 `GLOSSARY_CATEGORIES` 与测试允许分类一致，再运行 `npm run ai:index`。
 - MCP 工具必须保持只读，返回结果需包含可引用的 `citation.file` 或 URL。
 - 修改代码后至少运行相关 Vitest；完成前运行 `npm test` 和 `npm run lint`。

--- a/docs/operations/2026-05-15-daily-report.md
+++ b/docs/operations/2026-05-15-daily-report.md
@@ -12,12 +12,13 @@
 | Forks | 55 | 55 | 0 | `gh repo view beihaili/Get-Started-with-Web3` |
 | Watchers | 3 | 3 | 0 | `gh repo view beihaili/Get-Started-with-Web3` |
 | Open internal PRs | 0 | 0 | 0 | `gh pr list --state open` after #135 merge |
-| Open issues | 14 | 15 before #89 closure | -1 | `gh issue list --state open --limit 20` |
+| Open issues | 12 | 14 before #87/#93 closures | -2 | `gh issue list --state open --limit 30` |
 
 ## Completed
 
-- Learner mobile UX: prepared mobile reader drawer and swipe navigation for [#87](https://github.com/beihaili/Get-Started-with-Web3/issues/87), including a shared `useSwipe` hook that preserves vertical scroll and code-block horizontal scroll.
+- Learner mobile UX: shipped [#139](https://github.com/beihaili/Get-Started-with-Web3/pull/139), adding the mobile reader drawer and swipe navigation for [#87](https://github.com/beihaili/Get-Started-with-Web3/issues/87), including a shared `useSwipe` hook that preserves vertical scroll and code-block horizontal scroll.
 - Platform styling: corrected the Tailwind CSS v4 entrypoint so production builds generate theme utilities for colors, spacing, typography, and class-based dark mode; this surfaced during the #87 mobile visual smoke.
+- Content reliability: prepared a `sync-content` fallback so English lessons that reuse Chinese local images publish those referenced images instead of producing production 404s; this fixes the high-intent first-transaction lesson image gap found during production smoke.
 - Platform performance: prepared i18n namespace lazy loading for [#93](https://github.com/beihaili/Get-Started-with-Web3/issues/93), splitting UI locale payloads by route/feature while preserving existing `t('section.key')` calls. Local Vite main entry dropped from 107.59 kB / gzip 36.50 kB to 96.65 kB / gzip 32.04 kB.
 - Content: merged [#135](https://github.com/beihaili/Get-Started-with-Web3/pull/135), adding English-localized DeFi DEX quiz copy and stronger AMM, slippage, and impermanent-loss coverage. Closed [#89](https://github.com/beihaili/Get-Started-with-Web3/issues/89).
 - Platform performance: merged [#134](https://github.com/beihaili/Get-Started-with-Web3/pull/134), adding lesson-image lazy loading and generated image dimensions. Closed [#92](https://github.com/beihaili/Get-Started-with-Web3/issues/92).
@@ -32,8 +33,8 @@
 
 | Surface | Status | Evidence | Notes |
 | --- | --- | --- | --- |
-| Latest production deploy | Success | [Run 25904061676](https://github.com/beihaili/Get-Started-with-Web3/actions/runs/25904061676) | `feat: add localized DeFi DEX quiz (#135)` completed on main |
-| PR checks for latest shipment | Success | [#135](https://github.com/beihaili/Get-Started-with-Web3/pull/135) | Deploy and Lighthouse checks passed before merge |
+| Latest production deploy | Success | [Run 25919683746](https://github.com/beihaili/Get-Started-with-Web3/actions/runs/25919683746) | `feat: improve mobile reader navigation (#139)` completed on main |
+| PR checks for latest shipment | Success | [#139](https://github.com/beihaili/Get-Started-with-Web3/pull/139) | Deploy and Lighthouse checks passed before merge |
 | Local tests for #135 | Success | `npm test`: 28 files, 176 tests | Ran before PR and again after commit |
 | Local lint for #135 | Success | `npm run lint` | No ESLint output |
 | Local build for #135 | Success | `npm run build` | Prerendered 131/131 routes |
@@ -41,8 +42,10 @@
 | Browser smoke for #93 branch | Success | Playwright against local preview | `/en`, `/en/dashboard`, `/en/learn/module-8/8-2`, `/zh`, `/zh/glossary`, search modal, and language switch rendered without i18n key leaks or namespace load errors |
 | Local validation for #87 branch | Success | `npx vitest run src/hooks/__tests__/useSwipe.test.jsx src/pages/__tests__/ReaderPage.mobile.test.jsx`, `npm test`, `npm run lint`, `npm run build` | 5 targeted tests passed; 30 files and 183 tests passed; ESLint clean; build generated complete Tailwind CSS and prerendered 131/131 routes |
 | Browser smoke for #87 branch | Success | Playwright mobile viewport against local preview | Lesson drawer opens under 768px, traps focus, closes on Escape, swipes left/right navigate lessons, and code-block horizontal swipes do not navigate |
+| Local validation for image fallback branch | Success | `npx vitest run scripts/__tests__/sync-content.test.js`, `npm test`, `npm run lint`, `npm run ai:verify`, `npm run build` | Targeted sync-content tests pass; 30 files and 184 tests passed; ESLint clean; AI artifacts verified; build prerendered 131/131 routes |
 | AI entrypoints | Success | `npm run ai:verify` | Source/public artifacts, MCP tools, `llms.txt`, and x402 metadata verified |
-| Production smoke | Success | `https://beihaili.github.io/Get-Started-with-Web3/en/learn/module-8/8-2/` | English AMM quiz question rendered; no console or page errors |
+| Production smoke | Success | `https://beihaili.github.io/Get-Started-with-Web3/en/learn/module-8/8-2/` and `/en/learn/module-1/1-2/` | Mobile reader drawer/swipe works on production; first-transaction missing-image gap reproduced as local branch target and fixed locally |
+| Local browser smoke for image fallback branch | Success | Local preview on `/en/learn/module-1/1-2` | 13 referenced first-transaction images returned HTTP 200 image responses after `sync-content` fallback |
 
 ## External Distribution
 
@@ -68,12 +71,12 @@
 - Stars did not move yet: current count remains 614, so distribution and public-post execution remain the main growth bottleneck.
 - External PR #544 is still `CHANGES_REQUESTED/BLOCKED` even though the requested update was posted. This needs monitoring, not repeated comments yet.
 - Translation/proofreading issues remain open for modules 2, 4, and 5-6; English content quality is still a conversion risk for global learners.
-- Mobile reader UX is now locally verified in the [#87](https://github.com/beihaili/Get-Started-with-Web3/issues/87) branch; remaining work is PR review, CI, merge, and production smoke.
+- English first-transaction lesson images are locally fixed through `sync-content`, but the image fallback branch still needs PR review, CI, merge, and production smoke before the production 404 risk is closed.
 - Sponsor lead tracker now has named leads, but no outreach has been sent yet. First messages still need a current metrics refresh and exact channel selection.
 
 ## Next Operating Block
 
-1. Open, review, and ship the [#87](https://github.com/beihaili/Get-Started-with-Web3/issues/87) mobile reader UX PR, then convert it into a short public update once deployed.
+1. Open, review, and ship the image fallback PR, then smoke `/en/learn/module-1/1-2/` on production for missing image responses.
 2. Monitor [TensorBlock/awesome-mcp-servers#544](https://github.com/TensorBlock/awesome-mcp-servers/pull/544); if no reviewer response after a reasonable window, leave one concise follow-up.
 3. Prepare first sponsor outreach packet for Safe, Reown, or QuickNode; send only after metrics and sponsor-kit link are refreshed.
 
@@ -81,6 +84,6 @@
 
 - Main repository: https://github.com/beihaili/Get-Started-with-Web3
 - Latest production site: https://beihaili.github.io/Get-Started-with-Web3/
-- Latest merged PR: https://github.com/beihaili/Get-Started-with-Web3/pull/135
-- Latest main deploy: https://github.com/beihaili/Get-Started-with-Web3/actions/runs/25904061676
+- Latest merged PR: https://github.com/beihaili/Get-Started-with-Web3/pull/139
+- Latest main deploy: https://github.com/beihaili/Get-Started-with-Web3/actions/runs/25919683746
 - External MCP list PR: https://github.com/TensorBlock/awesome-mcp-servers/pull/544

--- a/docs/strategy/2026-05-14-execution-board.md
+++ b/docs/strategy/2026-05-14-execution-board.md
@@ -105,6 +105,7 @@ Update weekly.
 - [x] Split i18n locale payload by route/feature namespace and validate main bundle shrinkage for [#93](https://github.com/beihaili/Get-Started-with-Web3/issues/93).
 - [x] Improve mobile reader UX with a lesson drawer and swipe navigation for [#87](https://github.com/beihaili/Get-Started-with-Web3/issues/87).
 - [x] Correct Tailwind CSS v4 entrypoint so production builds emit full theme utilities and class-based dark mode styles.
+- [x] Add `sync-content` fallback coverage so English lessons do not ship broken local image references when the corresponding Chinese assets exist.
 - [ ] Keep Dependabot PRs under control; evaluate Tailwind/ESLint major upgrades separately.
 - [ ] Run `npm test`, `npm run lint`, and `npm run ai:verify` before claiming work is complete.
 - [ ] Run `npm run build` before shipping SEO/prerender changes.

--- a/scripts/__tests__/sync-content.test.js
+++ b/scripts/__tests__/sync-content.test.js
@@ -114,6 +114,57 @@ describe('sync-content', () => {
       height: 360,
     });
   });
+
+  it('fills missing English lesson images from the matching Chinese lesson assets', async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'web3-sync-content-'));
+    const zhLessonDir = path.join(tempDir, 'zh', 'Web3QuickStart', '02_FirstWeb3Transaction');
+    const enLessonDir = path.join(tempDir, 'en', 'Web3QuickStart', '02_FirstWeb3Transaction');
+    const image = createPngHeader(800, 450);
+
+    await mkdir(path.join(zhLessonDir, 'img'), { recursive: true });
+    await mkdir(enLessonDir, { recursive: true });
+    await writeFile(path.join(zhLessonDir, 'README.MD'), '# 中文\n', 'utf8');
+    await writeFile(path.join(zhLessonDir, 'img', '01.png'), image);
+    await writeFile(
+      path.join(enLessonDir, 'README.md'),
+      '# English\n\n<div><img src="./img/01.png" /></div>\n',
+      'utf8'
+    );
+
+    await syncContent({
+      projectRoot: tempDir,
+      courseData: [
+        {
+          lessons: [{ path: 'Web3QuickStart/02_FirstWeb3Transaction' }],
+        },
+      ],
+      logger: { log() {}, warn() {}, error() {} },
+    });
+
+    await expect(
+      readFile(
+        path.join(
+          tempDir,
+          'public',
+          'content',
+          'en',
+          'Web3QuickStart',
+          '02_FirstWeb3Transaction',
+          'img',
+          '01.png'
+        )
+      )
+    ).resolves.toEqual(image);
+
+    const metadata = JSON.parse(
+      await readFile(path.join(tempDir, 'public', 'content', 'image-metadata.json'), 'utf8')
+    );
+
+    expect(metadata['en/Web3QuickStart/02_FirstWeb3Transaction/img/01.png']).toEqual({
+      width: 800,
+      height: 450,
+    });
+  });
 });
 
 const createPngHeader = (width, height) => {

--- a/scripts/sync-content.mjs
+++ b/scripts/sync-content.mjs
@@ -14,6 +14,7 @@ const ensureExists = async (dir) => {
 
 const IMAGE_EXTENSIONS = new Set(['.gif', '.jpeg', '.jpg', '.png']);
 const IMAGE_METADATA_FILE = 'image-metadata.json';
+const README_FILE_PATTERN = /^README\.md$/i;
 
 const isImageFile = (filePath) => IMAGE_EXTENSIONS.has(path.extname(filePath).toLowerCase());
 
@@ -131,6 +132,91 @@ const writeImageMetadata = async (contentRoot, logger = console) => {
   logger.log(`[sync-content] Wrote ${Object.keys(metadata).length} image metadata entries`);
 };
 
+const cleanLocalAssetReference = (rawReference) => {
+  const reference = rawReference.split(/[?#]/)[0].trim();
+
+  if (
+    !reference ||
+    /^(?:[a-z][a-z0-9+.-]*:)?\/\//i.test(reference) ||
+    /^(?:data|mailto|tel):/i.test(reference) ||
+    reference.startsWith('#')
+  ) {
+    return null;
+  }
+
+  const normalized = path.normalize(reference);
+  if (path.isAbsolute(normalized) || normalized.startsWith('..')) {
+    return null;
+  }
+
+  return normalized;
+};
+
+const extractLocalImageReferences = (content) => {
+  const references = new Set();
+  const markdownImagePattern = /!\[[^\]]*]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g;
+  const htmlImagePattern = /<img\b[^>]*\bsrc=["']([^"']+)["'][^>]*>/gi;
+
+  for (const pattern of [markdownImagePattern, htmlImagePattern]) {
+    for (const match of content.matchAll(pattern)) {
+      const reference = cleanLocalAssetReference(match[1]);
+      if (reference && isImageFile(reference)) {
+        references.add(reference);
+      }
+    }
+  }
+
+  return [...references];
+};
+
+const copyMissingReferencedImages = async (fallbackFolder, targetFolder, logger = console) => {
+  const visit = async (dir) => {
+    const entries = await readdir(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const entryPath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        await visit(entryPath);
+        continue;
+      }
+
+      if (!entry.isFile() || !README_FILE_PATTERN.test(entry.name)) {
+        continue;
+      }
+
+      const content = await readFile(entryPath, 'utf8');
+      const readmeDir = path.dirname(entryPath);
+
+      for (const reference of extractLocalImageReferences(content)) {
+        const targetImage = path.resolve(readmeDir, reference);
+        const targetRelative = path.relative(targetFolder, targetImage);
+
+        if (targetRelative.startsWith('..') || path.isAbsolute(targetRelative)) {
+          continue;
+        }
+
+        if (existsSync(targetImage)) {
+          continue;
+        }
+
+        const fallbackImage = path.join(fallbackFolder, targetRelative);
+        if (!existsSync(fallbackImage)) {
+          continue;
+        }
+
+        await ensureExists(path.dirname(targetImage));
+        await cp(fallbackImage, targetImage);
+        logger.log(
+          `[sync-content] Copied fallback image ${fallbackImage} -> ${targetImage}`
+        );
+      }
+    }
+  };
+
+  await visit(targetFolder);
+};
+
 export const getSourceFoldersFromCourseData = (courseData = COURSE_DATA) => {
   const folders = new Set();
 
@@ -196,6 +282,7 @@ export const syncContent = async (options = {}) => {
     const dest = path.join(enTarget, folder);
     if (existsSync(src)) {
       await safeCopy(src, dest, logger);
+      await copyMissingReferencedImages(path.join(root, 'zh', folder), dest, logger);
     }
   }
 


### PR DESCRIPTION
## Summary
- Copy missing local images referenced by English lesson READMEs from the matching Chinese lesson folder during `sync-content`.
- Preserve any existing English-specific images and only fill missing referenced assets.
- Add regression coverage for the fallback behavior and update operating docs.

## Why
The English first Web3 transaction lesson referenced `./img/*.jpg`, but those shared screenshots only existed under the matching Chinese lesson folder. After publish, GitHub Pages returned 404s for those lesson images. This makes the content sync step publish shared lesson assets consistently.

## Validation
- `npx vitest run scripts/__tests__/sync-content.test.js`
- `npm test` (30 files, 184 tests)
- `npm run lint`
- `npm run ai:verify`
- `npm run build` (87 image metadata entries; 59 OG images; 131/131 prerendered routes)
- Local preview direct fetch: `01.jpg` through `13.jpg` for `/content/en/Web3QuickStart/02_FirstWeb3Transaction/img/` all returned HTTP 200 with `image/jpeg`.
