### PR TITLE
[codex] Add PR build artifact comment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,17 +62,57 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
 
+      - name: Upload PR build artifact 📦
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-${{ github.event.pull_request.number }}-dist
+          path: ./dist
+          if-no-files-found: error
+          retention-days: 7
+
       - name: Comment PR with Preview Link 💬
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v9
         with:
           script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '📦 **构建成功！** 在合并到 main 分支后将自动部署到生产环境。'
-            })
+            const marker = '<!-- pr-preview-artifact-link -->';
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const body = [
+              marker,
+              '📦 **构建成功！** PR 构建产物已上传，可从 Actions run 页面下载 `dist` artifact 进行本地预览。',
+              '',
+              `- 🔎 [打开本次 Actions run / 下载构建产物](${runUrl})`,
+              '- 🚀 合并到 `main` 后会自动部署到生产环境。',
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const previousComment = comments.data.find((comment) => (
+              comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            ));
+
+            if (previousComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: previousComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
 
       - name: Output deployment URL 🌐
         if: github.ref == 'refs/heads/main'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@
 - `CONTRIBUTING.md` / `CONTRIBUTING.en.md`: 双语贡献指南，维护贡献路径、验证矩阵和内容质量标准。
 - `.github/ISSUE_TEMPLATE/`: Bug、feature、content/translation、growth/community 分流模板。
 - `.github/PULL_REQUEST_TEMPLATE.md`: PR 验证和内容安全检查清单。
+- `.github/workflows/deploy.yml`: PR 构建会上传 `dist` artifact，并用固定 marker 更新同一条 PR 评论，方便评审者从 Actions run 下载构建产物；合并到 `main` 后才部署 GitHub Pages。
 
 工作边界：
 

--- a/docs/operations/2026-05-15-daily-report.md
+++ b/docs/operations/2026-05-15-daily-report.md
@@ -6,19 +6,20 @@
 
 ## KPI Snapshot
 
-| Metric | Current | Previous / Baseline | Movement | Source |
-| --- | ---: | ---: | ---: | --- |
-| GitHub stars | 614 | 614 short-term baseline | 0 | `gh repo view beihaili/Get-Started-with-Web3` |
-| Forks | 55 | 55 | 0 | `gh repo view beihaili/Get-Started-with-Web3` |
-| Watchers | 3 | 3 | 0 | `gh repo view beihaili/Get-Started-with-Web3` |
-| Open internal PRs | 0 | 0 | 0 | `gh pr list --state open` after #135 merge |
-| Open issues | 12 | 14 before #87/#93 closures | -2 | `gh issue list --state open --limit 30` |
+| Metric            | Current |        Previous / Baseline | Movement | Source                                                                                                |
+| ----------------- | ------: | -------------------------: | -------: | ----------------------------------------------------------------------------------------------------- |
+| GitHub stars      |     614 |    614 short-term baseline |        0 | `gh repo view beihaili/Get-Started-with-Web3`                                                         |
+| Forks             |      55 |                         55 |        0 | `gh repo view beihaili/Get-Started-with-Web3`                                                         |
+| Watchers          |       3 |                          3 |        0 | `gh repo view beihaili/Get-Started-with-Web3`                                                         |
+| Open internal PRs |       0 |                          0 |        0 | `gh pr list --state open` after #135 merge                                                            |
+| Open issues       |      12 | 14 before #87/#93 closures |       -2 | `gh issue list --state open --limit 30`; #40 queued to close after PR preview artifact workflow ships |
 
 ## Completed
 
+- Contributor workflow: prepared the [#40](https://github.com/beihaili/Get-Started-with-Web3/issues/40) PR feedback fix so pull request builds upload a downloadable `dist` artifact and update one stable review comment with the Actions run link.
+- Content reliability: shipped [#140](https://github.com/beihaili/Get-Started-with-Web3/pull/140), adding a `sync-content` fallback so English lessons that reuse Chinese local images publish those referenced images instead of producing production 404s; production smoke confirmed all 13 first-transaction lesson images return HTTP 200 image responses.
 - Learner mobile UX: shipped [#139](https://github.com/beihaili/Get-Started-with-Web3/pull/139), adding the mobile reader drawer and swipe navigation for [#87](https://github.com/beihaili/Get-Started-with-Web3/issues/87), including a shared `useSwipe` hook that preserves vertical scroll and code-block horizontal scroll.
 - Platform styling: corrected the Tailwind CSS v4 entrypoint so production builds generate theme utilities for colors, spacing, typography, and class-based dark mode; this surfaced during the #87 mobile visual smoke.
-- Content reliability: prepared a `sync-content` fallback so English lessons that reuse Chinese local images publish those referenced images instead of producing production 404s; this fixes the high-intent first-transaction lesson image gap found during production smoke.
 - Platform performance: prepared i18n namespace lazy loading for [#93](https://github.com/beihaili/Get-Started-with-Web3/issues/93), splitting UI locale payloads by route/feature while preserving existing `t('section.key')` calls. Local Vite main entry dropped from 107.59 kB / gzip 36.50 kB to 96.65 kB / gzip 32.04 kB.
 - Content: merged [#135](https://github.com/beihaili/Get-Started-with-Web3/pull/135), adding English-localized DeFi DEX quiz copy and stronger AMM, slippage, and impermanent-loss coverage. Closed [#89](https://github.com/beihaili/Get-Started-with-Web3/issues/89).
 - Platform performance: merged [#134](https://github.com/beihaili/Get-Started-with-Web3/pull/134), adding lesson-image lazy loading and generated image dimensions. Closed [#92](https://github.com/beihaili/Get-Started-with-Web3/issues/92).
@@ -31,52 +32,52 @@
 
 ## Deploy And Verification
 
-| Surface | Status | Evidence | Notes |
-| --- | --- | --- | --- |
-| Latest production deploy | Success | [Run 25919683746](https://github.com/beihaili/Get-Started-with-Web3/actions/runs/25919683746) | `feat: improve mobile reader navigation (#139)` completed on main |
-| PR checks for latest shipment | Success | [#139](https://github.com/beihaili/Get-Started-with-Web3/pull/139) | Deploy and Lighthouse checks passed before merge |
-| Local tests for #135 | Success | `npm test`: 28 files, 176 tests | Ran before PR and again after commit |
-| Local lint for #135 | Success | `npm run lint` | No ESLint output |
-| Local build for #135 | Success | `npm run build` | Prerendered 131/131 routes |
-| Local validation for #93 branch | Success | `npm test`, `npm run lint`, `npm run build` | 178 tests passed; ESLint clean; build generated 59 OG images and prerendered 131/131 routes |
-| Browser smoke for #93 branch | Success | Playwright against local preview | `/en`, `/en/dashboard`, `/en/learn/module-8/8-2`, `/zh`, `/zh/glossary`, search modal, and language switch rendered without i18n key leaks or namespace load errors |
-| Local validation for #87 branch | Success | `npx vitest run src/hooks/__tests__/useSwipe.test.jsx src/pages/__tests__/ReaderPage.mobile.test.jsx`, `npm test`, `npm run lint`, `npm run build` | 5 targeted tests passed; 30 files and 183 tests passed; ESLint clean; build generated complete Tailwind CSS and prerendered 131/131 routes |
-| Browser smoke for #87 branch | Success | Playwright mobile viewport against local preview | Lesson drawer opens under 768px, traps focus, closes on Escape, swipes left/right navigate lessons, and code-block horizontal swipes do not navigate |
-| Local validation for image fallback branch | Success | `npx vitest run scripts/__tests__/sync-content.test.js`, `npm test`, `npm run lint`, `npm run ai:verify`, `npm run build` | Targeted sync-content tests pass; 30 files and 184 tests passed; ESLint clean; AI artifacts verified; build prerendered 131/131 routes |
-| AI entrypoints | Success | `npm run ai:verify` | Source/public artifacts, MCP tools, `llms.txt`, and x402 metadata verified |
-| Production smoke | Success | `https://beihaili.github.io/Get-Started-with-Web3/en/learn/module-8/8-2/` and `/en/learn/module-1/1-2/` | Mobile reader drawer/swipe works on production; first-transaction missing-image gap reproduced as local branch target and fixed locally |
-| Local browser smoke for image fallback branch | Success | Local preview on `/en/learn/module-1/1-2` | 13 referenced first-transaction images returned HTTP 200 image responses after `sync-content` fallback |
+| Surface                                       | Status  | Evidence                                                                                                                                           | Notes                                                                                                                                                               |
+| --------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Latest production deploy                      | Success | [Run 25921739161](https://github.com/beihaili/Get-Started-with-Web3/actions/runs/25921739161)                                                      | `fix: publish fallback lesson images (#140)` completed on main                                                                                                      |
+| PR checks for latest shipment                 | Success | [#140](https://github.com/beihaili/Get-Started-with-Web3/pull/140)                                                                                 | Deploy and Lighthouse checks passed before merge                                                                                                                    |
+| Local validation for #40 branch               | Success | `npx vitest run scripts/__tests__/deploy-workflow.test.js`                                                                                         | Regression test covers PR artifact upload, clickable Actions run link, and updating the existing PR comment                                                         |
+| Local tests for #135                          | Success | `npm test`: 28 files, 176 tests                                                                                                                    | Ran before PR and again after commit                                                                                                                                |
+| Local lint for #135                           | Success | `npm run lint`                                                                                                                                     | No ESLint output                                                                                                                                                    |
+| Local build for #135                          | Success | `npm run build`                                                                                                                                    | Prerendered 131/131 routes                                                                                                                                          |
+| Local validation for #93 branch               | Success | `npm test`, `npm run lint`, `npm run build`                                                                                                        | 178 tests passed; ESLint clean; build generated 59 OG images and prerendered 131/131 routes                                                                         |
+| Browser smoke for #93 branch                  | Success | Playwright against local preview                                                                                                                   | `/en`, `/en/dashboard`, `/en/learn/module-8/8-2`, `/zh`, `/zh/glossary`, search modal, and language switch rendered without i18n key leaks or namespace load errors |
+| Local validation for #87 branch               | Success | `npx vitest run src/hooks/__tests__/useSwipe.test.jsx src/pages/__tests__/ReaderPage.mobile.test.jsx`, `npm test`, `npm run lint`, `npm run build` | 5 targeted tests passed; 30 files and 183 tests passed; ESLint clean; build generated complete Tailwind CSS and prerendered 131/131 routes                          |
+| Browser smoke for #87 branch                  | Success | Playwright mobile viewport against local preview                                                                                                   | Lesson drawer opens under 768px, traps focus, closes on Escape, swipes left/right navigate lessons, and code-block horizontal swipes do not navigate                |
+| Local validation for image fallback branch    | Success | `npx vitest run scripts/__tests__/sync-content.test.js`, `npm test`, `npm run lint`, `npm run ai:verify`, `npm run build`                          | Targeted sync-content tests pass; 30 files and 184 tests passed; ESLint clean; AI artifacts verified; build prerendered 131/131 routes                              |
+| AI entrypoints                                | Success | `npm run ai:verify`                                                                                                                                | Source/public artifacts, MCP tools, `llms.txt`, and x402 metadata verified                                                                                          |
+| Production smoke                              | Success | `https://beihaili.github.io/Get-Started-with-Web3/en/learn/module-8/8-2/` and `/en/learn/module-1/1-2/`                                            | Mobile reader drawer/swipe works on production; first-transaction images `01.jpg` through `13.jpg` returned HTTP 200 image responses after #140 deploy              |
+| Local browser smoke for image fallback branch | Success | Local preview on `/en/learn/module-1/1-2`                                                                                                          | 13 referenced first-transaction images returned HTTP 200 image responses after `sync-content` fallback                                                              |
 
 ## External Distribution
 
-| Target | Status | Evidence | Next action |
-| --- | --- | --- | --- |
-| TensorBlock `awesome-mcp-servers` | Open, waiting re-review | [PR #544](https://github.com/TensorBlock/awesome-mcp-servers/pull/544) | Reviewer requested matching docs entry; update was posted on 2026-05-15 01:02:45 UTC. Monitor for review response before further nudging. |
-| Public post queue | Drafted, not yet published | `docs/strategy/2026-05-15-public-post-drafts.md` | Publish one low-risk post after external PR is no longer blocked or after next content improvement lands. |
+| Target                            | Status                     | Evidence                                                               | Next action                                                                                                                               |
+| --------------------------------- | -------------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| TensorBlock `awesome-mcp-servers` | Open, waiting re-review    | [PR #544](https://github.com/TensorBlock/awesome-mcp-servers/pull/544) | Reviewer requested matching docs entry; update was posted on 2026-05-15 01:02:45 UTC. Monitor for review response before further nudging. |
+| Public post queue                 | Drafted, not yet published | `docs/strategy/2026-05-15-public-post-drafts.md`                       | Publish one low-risk post after external PR is no longer blocked or after next content improvement lands.                                 |
 
 ## Sponsor And Revenue
 
-| Lead / Channel | Status | Next action | Risk notes |
-| --- | --- | --- | --- |
-| Safe Ecosystem Foundation | Queued lead | Prepare grant-style impact memo for smart account and account abstraction education | Low trust risk; keep outputs educational and open-source |
-| Reown / WalletConnect | Queued lead | Personalize wallet UX and connection-safety outreach | Avoid implying endorsement of any specific wallet |
-| QuickNode | Queued lead | Personalize infrastructure sponsor outreach around builder labs and RPC lessons | Do not promise developer acquisition numbers yet |
-| Blockaid / Blowfish | Queued security leads | Pick one first security outreach to avoid overlapping asks | Keep security claims factual and tool-neutral |
-| Ethereum Foundation ESP | Researching | Package public-goods impact memo after more usage metrics | Grant path, not commercial sponsor |
-| L2 ecosystems | Researching | Match sponsorship ask to L2/bridge learning modules | Avoid chain-promotion claims that weaken educational neutrality |
-| Exchanges / affiliate | Policy review needed | Review donation and affiliate disclosures before outreach | High trust risk; require explicit confirmation before accepting sensitive sponsorship |
+| Lead / Channel            | Status                | Next action                                                                         | Risk notes                                                                            |
+| ------------------------- | --------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Safe Ecosystem Foundation | Queued lead           | Prepare grant-style impact memo for smart account and account abstraction education | Low trust risk; keep outputs educational and open-source                              |
+| Reown / WalletConnect     | Queued lead           | Personalize wallet UX and connection-safety outreach                                | Avoid implying endorsement of any specific wallet                                     |
+| QuickNode                 | Queued lead           | Personalize infrastructure sponsor outreach around builder labs and RPC lessons     | Do not promise developer acquisition numbers yet                                      |
+| Blockaid / Blowfish       | Queued security leads | Pick one first security outreach to avoid overlapping asks                          | Keep security claims factual and tool-neutral                                         |
+| Ethereum Foundation ESP   | Researching           | Package public-goods impact memo after more usage metrics                           | Grant path, not commercial sponsor                                                    |
+| L2 ecosystems             | Researching           | Match sponsorship ask to L2/bridge learning modules                                 | Avoid chain-promotion claims that weaken educational neutrality                       |
+| Exchanges / affiliate     | Policy review needed  | Review donation and affiliate disclosures before outreach                           | High trust risk; require explicit confirmation before accepting sensitive sponsorship |
 
 ## Blockers And Risks
 
 - Stars did not move yet: current count remains 614, so distribution and public-post execution remain the main growth bottleneck.
 - External PR #544 is still `CHANGES_REQUESTED/BLOCKED` even though the requested update was posted. This needs monitoring, not repeated comments yet.
 - Translation/proofreading issues remain open for modules 2, 4, and 5-6; English content quality is still a conversion risk for global learners.
-- English first-transaction lesson images are locally fixed through `sync-content`, but the image fallback branch still needs PR review, CI, merge, and production smoke before the production 404 risk is closed.
 - Sponsor lead tracker now has named leads, but no outreach has been sent yet. First messages still need a current metrics refresh and exact channel selection.
 
 ## Next Operating Block
 
-1. Open, review, and ship the image fallback PR, then smoke `/en/learn/module-1/1-2/` on production for missing image responses.
+1. Ship the #40 PR preview artifact comment fix, confirm the bot updates one existing PR comment on a follow-up push, then close #40.
 2. Monitor [TensorBlock/awesome-mcp-servers#544](https://github.com/TensorBlock/awesome-mcp-servers/pull/544); if no reviewer response after a reasonable window, leave one concise follow-up.
 3. Prepare first sponsor outreach packet for Safe, Reown, or QuickNode; send only after metrics and sponsor-kit link are refreshed.
 
@@ -84,6 +85,6 @@
 
 - Main repository: https://github.com/beihaili/Get-Started-with-Web3
 - Latest production site: https://beihaili.github.io/Get-Started-with-Web3/
-- Latest merged PR: https://github.com/beihaili/Get-Started-with-Web3/pull/139
-- Latest main deploy: https://github.com/beihaili/Get-Started-with-Web3/actions/runs/25919683746
+- Latest merged PR: https://github.com/beihaili/Get-Started-with-Web3/pull/140
+- Latest main deploy: https://github.com/beihaili/Get-Started-with-Web3/actions/runs/25921739161
 - External MCP list PR: https://github.com/TensorBlock/awesome-mcp-servers/pull/544

--- a/docs/strategy/2026-05-14-execution-board.md
+++ b/docs/strategy/2026-05-14-execution-board.md
@@ -106,6 +106,7 @@ Update weekly.
 - [x] Improve mobile reader UX with a lesson drawer and swipe navigation for [#87](https://github.com/beihaili/Get-Started-with-Web3/issues/87).
 - [x] Correct Tailwind CSS v4 entrypoint so production builds emit full theme utilities and class-based dark mode styles.
 - [x] Add `sync-content` fallback coverage so English lessons do not ship broken local image references when the corresponding Chinese assets exist.
+- [x] Prepare PR build artifact comments for [#40](https://github.com/beihaili/Get-Started-with-Web3/issues/40) so contributors can download reviewed builds from the Actions run.
 - [ ] Keep Dependabot PRs under control; evaluate Tailwind/ESLint major upgrades separately.
 - [ ] Run `npm test`, `npm run lint`, and `npm run ai:verify` before claiming work is complete.
 - [ ] Run `npm run build` before shipping SEO/prerender changes.
@@ -138,14 +139,14 @@ Update weekly.
 
 Detailed tracker: `docs/strategy/2026-05-15-sponsor-leads-tracker.md`.
 
-| Sponsor | Category | Fit | Status | Next Action |
-| --- | --- | --- | --- | --- |
-| Safe Ecosystem Foundation | Smart accounts / grants | Account abstraction, wallet recovery, security education | Queued | Prepare grant-style impact memo |
-| Reown / WalletConnect | Wallet UX / connectivity infra | Wallet connection safety and onboarding UX | Queued | Personalize wallet sponsor outreach |
-| QuickNode | RPC / infrastructure | Builder labs, RPC lessons, developer onboarding | Queued | Personalize infrastructure sponsor outreach |
-| Blockaid or Blowfish | Security tooling | Scam, approval, signing, and transaction-warning education | Queued | Pick one first security outreach |
-| Ethereum Foundation ESP | Public goods / grants | AI-native open-source Ethereum learning resources | Researching | Package public-goods impact memo |
-| Exchanges | Exchange / affiliate | CEX onboarding and fiat on-ramp | Hold | Requires explicit trust-policy review before contact |
+| Sponsor                   | Category                       | Fit                                                        | Status      | Next Action                                          |
+| ------------------------- | ------------------------------ | ---------------------------------------------------------- | ----------- | ---------------------------------------------------- |
+| Safe Ecosystem Foundation | Smart accounts / grants        | Account abstraction, wallet recovery, security education   | Queued      | Prepare grant-style impact memo                      |
+| Reown / WalletConnect     | Wallet UX / connectivity infra | Wallet connection safety and onboarding UX                 | Queued      | Personalize wallet sponsor outreach                  |
+| QuickNode                 | RPC / infrastructure           | Builder labs, RPC lessons, developer onboarding            | Queued      | Personalize infrastructure sponsor outreach          |
+| Blockaid or Blowfish      | Security tooling               | Scam, approval, signing, and transaction-warning education | Queued      | Pick one first security outreach                     |
+| Ethereum Foundation ESP   | Public goods / grants          | AI-native open-source Ethereum learning resources          | Researching | Package public-goods impact memo                     |
+| Exchanges                 | Exchange / affiliate           | CEX onboarding and fiat on-ramp                            | Hold        | Requires explicit trust-policy review before contact |
 
 ## Reporting Template
 

--- a/scripts/__tests__/deploy-workflow.test.js
+++ b/scripts/__tests__/deploy-workflow.test.js
@@ -1,0 +1,24 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '../..');
+
+describe('deploy workflow PR feedback', () => {
+  it('posts an updatable PR comment with a build artifact link', async () => {
+    const workflow = await readFile(path.join(projectRoot, '.github/workflows/deploy.yml'), 'utf8');
+
+    expect(workflow).toContain("if: github.event_name == 'pull_request'");
+    expect(workflow).toContain('actions/upload-artifact@v4');
+    expect(workflow).toContain('path: ./dist');
+    expect(workflow).toContain('GITHUB_RUN_ID');
+    expect(workflow).toContain('/actions/runs/');
+    expect(workflow).toContain('<!-- pr-preview-artifact-link -->');
+    expect(workflow).toContain('github.rest.issues.listComments');
+    expect(workflow).toContain('github.rest.issues.updateComment');
+    expect(workflow).toContain('github.rest.issues.createComment');
+  });
+});


### PR DESCRIPTION
## Summary
- Upload the built `dist` directory as a pull request artifact after PR builds.
- Replace the one-off build-success comment with a stable marker-based comment that links to the Actions run and updates on later pushes.
- Add a workflow regression test and update the operating notes for the contributor review flow.

## Why
Issue #40 asks for reviewers to get a clickable preview or artifact link when a PR build completes, and for subsequent pushes to update the same comment instead of adding duplicate bot comments. A full preview deployment is not configured for PRs, so this implements the documented fallback: a downloadable build artifact linked from the PR comment.

Closes #40

## Validation
- Red: `npx vitest run scripts/__tests__/deploy-workflow.test.js` failed before the workflow uploaded artifacts or updated comments.
- Green: `npx vitest run scripts/__tests__/deploy-workflow.test.js`
- `npx eslint scripts/__tests__/deploy-workflow.test.js`
- `npm test` (31 files, 185 tests)
- `npm run lint`
- `npx prettier --check .github/workflows/deploy.yml scripts/__tests__/deploy-workflow.test.js AGENTS.md docs/operations/2026-05-15-daily-report.md docs/strategy/2026-05-14-execution-board.md`
- `npm run ai:verify`
- `npm run build` (59 OG images; 131/131 prerendered routes)
