### PR TITLE
[codex] Add 2026-05-16 operations report

### DIFF
--- a/docs/operations/2026-05-16-daily-report.md
+++ b/docs/operations/2026-05-16-daily-report.md
@@ -1,0 +1,72 @@
+# Get Started with Web3 Daily Operations Report
+
+**Date:** 2026-05-16
+**Owner:** beihai + Codex
+**Reporting window:** 2026-05-16 14:10 CST snapshot; GitHub timestamps are UTC unless noted.
+
+## KPI Snapshot
+
+| Metric       | Current | Previous / Baseline | Movement | Source                                                |
+| ------------ | ------: | ------------------: | -------: | ----------------------------------------------------- |
+| GitHub stars |     614 |                 614 |        0 | `gh repo view beihaili/Get-Started-with-Web3`         |
+| Forks        |      56 |                  55 |       +1 | `gh repo view beihaili/Get-Started-with-Web3`         |
+| Watchers     |       3 |                   3 |        0 | `gh repo view beihaili/Get-Started-with-Web3`         |
+| Open PRs     |       0 |                   3 |       -3 | `gh pr list --state open` after #142/#143/#144 merges |
+| Open issues  |       8 |                  12 |       -4 | `gh issue list --state open --limit 30`               |
+
+## Completed
+
+- Platform reliability: shipped [#141](https://github.com/beihaili/Get-Started-with-Web3/pull/141), adding PR build artifacts and an updatable Actions-run comment for reviewers. Closed [#40](https://github.com/beihaili/Get-Started-with-Web3/issues/40).
+- Community contribution flow: merged external contributor PRs [#142](https://github.com/beihaili/Get-Started-with-Web3/pull/142), [#143](https://github.com/beihaili/Get-Started-with-Web3/pull/143), and [#144](https://github.com/beihaili/Get-Started-with-Web3/pull/144). Closed [#36](https://github.com/beihaili/Get-Started-with-Web3/issues/36), [#37](https://github.com/beihaili/Get-Started-with-Web3/issues/37), and [#38](https://github.com/beihaili/Get-Started-with-Web3/issues/38).
+- Product quality: #144 added keyboard navigation for quiz answer options, including Arrow key movement, wrapping, Enter/Space selection, and focus rings.
+- Test coverage: #142 added SponsorSection/SponsorBanner coverage; #143 added DonationSection coverage for donation links, affiliate links, and wallet addresses.
+- Growth signal: fork count moved from 55 to 56 while stars stayed flat at 614.
+
+## Deploy And Verification
+
+| Surface                   | Status  | Evidence                                                                                      | Notes                                                                                 |
+| ------------------------- | ------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Latest production deploy  | Success | [Run 25954416178](https://github.com/beihaili/Get-Started-with-Web3/actions/runs/25954416178) | `feat: add quiz keyboard navigation (#144)` completed on main                         |
+| PR artifact workflow      | Success | [#141](https://github.com/beihaili/Get-Started-with-Web3/pull/141)                            | `pr-141-dist` artifact uploaded; marker comment updated to run `25923344253`          |
+| Local review for #142     | Success | `npx vitest run src/components/__tests__/SponsorComponents.test.jsx`; `npx eslint ...`        | 4 tests passed; ESLint clean                                                          |
+| Local review for #143     | Success | `npx vitest run src/components/__tests__/DonationSection.test.jsx`; `npx eslint ...`          | 3 tests passed; ESLint clean                                                          |
+| Local review for #144     | Success | `npx vitest run src/features/quiz/__tests__/MultiQuiz.test.jsx`; `npm test`; `npx eslint ...` | Targeted quiz tests passed; full suite passed with 31 files and 186 tests             |
+| Production quiz smoke     | Success | Playwright against `/en/learn/module-8/8-2/?v=962ebab`                                        | Start Challenge, focus first answer, ArrowDown focus move, Space selection all worked |
+| Production public entries | Success | Homepage, `/llms.txt`, and `/ai/manifest.json` returned HTTP 200 after #141 deploy            | Validated after run `25948710891`                                                     |
+
+## External Distribution
+
+| Target                            | Status                  | Evidence                                                               | Next action                                                                                      |
+| --------------------------------- | ----------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| TensorBlock `awesome-mcp-servers` | Open, waiting re-review | [PR #544](https://github.com/TensorBlock/awesome-mcp-servers/pull/544) | Reviewer requested docs mirror entry; update posted on 2026-05-15 01:02:45 UTC. Wait, then nudge |
+| Public post queue                 | Drafted                 | `docs/strategy/2026-05-15-public-post-drafts.md`                       | Publish one low-risk post after the external PR is unblocked or next content PR lands            |
+
+## Sponsor And Revenue
+
+| Lead / Channel            | Status | Next action                                                                         | Risk notes                                                     |
+| ------------------------- | ------ | ----------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| Safe Ecosystem Foundation | Queued | Prepare grant-style impact memo for smart account and account abstraction education | Low trust risk; open-source and education aligned              |
+| Reown / WalletConnect     | Queued | Personalize wallet UX and connection-safety outreach                                | Avoid implying wallet endorsement                              |
+| QuickNode                 | Queued | Personalize infrastructure sponsor outreach around builder labs and RPC lessons     | Do not promise developer acquisition numbers yet               |
+| Exchanges / affiliate     | Hold   | Requires explicit trust-policy review before contact                                | High trust risk; needs user confirmation before any acceptance |
+
+## Blockers And Risks
+
+- Stars stayed at 614; the 1000-star goal still needs external distribution and public-post execution, not only repository maintenance.
+- External MCP-list PR #544 remains `CHANGES_REQUESTED/BLOCKED`; repeated comments before reviewer response may hurt signal quality.
+- Open issue backlog is down to 8, but English proofreading issues #13/#15/#16 remain a conversion-quality risk.
+- Sponsor outreach has not been sent; the next message needs current metrics and a clear sponsor-kit link.
+
+## Next Operating Block
+
+1. Monitor [TensorBlock/awesome-mcp-servers#544](https://github.com/TensorBlock/awesome-mcp-servers/pull/544); leave one concise follow-up if there is still no response after a reasonable window.
+2. Pick the next beginner-friendly issue from #35, #84, or #85, or review any new contributor PR within 24 hours.
+3. Prepare the first low-risk sponsor outreach packet for Safe, Reown, or QuickNode.
+
+## Evidence Links
+
+- Repository: https://github.com/beihaili/Get-Started-with-Web3
+- Production site: https://beihaili.github.io/Get-Started-with-Web3/
+- Latest merged PR: https://github.com/beihaili/Get-Started-with-Web3/pull/144
+- Latest main deploy: https://github.com/beihaili/Get-Started-with-Web3/actions/runs/25954416178
+- External MCP-list PR: https://github.com/TensorBlock/awesome-mcp-servers/pull/544


### PR DESCRIPTION
## Summary
- Add the 2026-05-16 daily operations report.
- Record #141 through #144, issue closures #36/#37/#38/#40, latest metrics, deployment evidence, and next operating block.

## Validation
- `npx prettier --check docs/operations/2026-05-16-daily-report.md`
- `git diff --check`
