### PR TITLE
[codex] Add LanguageSwitcher active-state tests

### DIFF
--- a/docs/operations/2026-05-16-daily-report.md
+++ b/docs/operations/2026-05-16-daily-report.md
@@ -2,16 +2,16 @@
 
 **Date:** 2026-05-16
 **Owner:** beihai + Codex
-**Reporting window:** 2026-05-16 14:10 CST snapshot; GitHub timestamps are UTC unless noted.
+**Reporting window:** 2026-05-16 14:51 CST snapshot; GitHub timestamps are UTC unless noted.
 
 ## KPI Snapshot
 
 | Metric       | Current | Previous / Baseline | Movement | Source                                                |
 | ------------ | ------: | ------------------: | -------: | ----------------------------------------------------- |
 | GitHub stars |     614 |                 614 |        0 | `gh repo view beihaili/Get-Started-with-Web3`         |
-| Forks        |      56 |                  55 |       +1 | `gh repo view beihaili/Get-Started-with-Web3`         |
+| Forks        |      55 |                  55 |        0 | `gh repo view beihaili/Get-Started-with-Web3`         |
 | Watchers     |       3 |                   3 |        0 | `gh repo view beihaili/Get-Started-with-Web3`         |
-| Open PRs     |       0 |                   3 |       -3 | `gh pr list --state open` after #142/#143/#144 merges |
+| Open PRs     |       1 |                   3 |       -2 | `gh pr list --state open` after #147 opened           |
 | Open issues  |       8 |                  12 |       -4 | `gh issue list --state open --limit 30`               |
 
 ## Completed
@@ -20,19 +20,23 @@
 - Community contribution flow: merged external contributor PRs [#142](https://github.com/beihaili/Get-Started-with-Web3/pull/142), [#143](https://github.com/beihaili/Get-Started-with-Web3/pull/143), and [#144](https://github.com/beihaili/Get-Started-with-Web3/pull/144). Closed [#36](https://github.com/beihaili/Get-Started-with-Web3/issues/36), [#37](https://github.com/beihaili/Get-Started-with-Web3/issues/37), and [#38](https://github.com/beihaili/Get-Started-with-Web3/issues/38).
 - Product quality: #144 added keyboard navigation for quiz answer options, including Arrow key movement, wrapping, Enter/Space selection, and focus rings.
 - Test coverage: #142 added SponsorSection/SponsorBanner coverage; #143 added DonationSection coverage for donation links, affiliate links, and wallet addresses.
-- Growth signal: fork count moved from 55 to 56 while stars stayed flat at 614.
+- Operations hygiene: shipped [#145](https://github.com/beihaili/Get-Started-with-Web3/pull/145) for the 2026-05-16 daily report and [#146](https://github.com/beihaili/Get-Started-with-Web3/pull/146) to record the TensorBlock follow-up.
+- Backlog execution: opened draft [#147](https://github.com/beihaili/Get-Started-with-Web3/pull/147) for [#35](https://github.com/beihaili/Get-Started-with-Web3/issues/35), adding LanguageSwitcher active-state tests and a compact EN/中文 selector.
+- Growth signal: stars stayed flat at 614 and forks are back at 55 in the latest snapshot.
 
 ## Deploy And Verification
 
 | Surface                   | Status  | Evidence                                                                                      | Notes                                                                                 |
 | ------------------------- | ------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| Latest production deploy  | Success | [Run 25954416178](https://github.com/beihaili/Get-Started-with-Web3/actions/runs/25954416178) | `feat: add quiz keyboard navigation (#144)` completed on main                         |
+| Latest production deploy  | Success | [Run 25954994993](https://github.com/beihaili/Get-Started-with-Web3/actions/runs/25954994993) | `docs: record awesome MCP follow-up (#146)` completed on main                         |
 | PR artifact workflow      | Success | [#141](https://github.com/beihaili/Get-Started-with-Web3/pull/141)                            | `pr-141-dist` artifact uploaded; marker comment updated to run `25923344253`          |
 | Local review for #142     | Success | `npx vitest run src/components/__tests__/SponsorComponents.test.jsx`; `npx eslint ...`        | 4 tests passed; ESLint clean                                                          |
 | Local review for #143     | Success | `npx vitest run src/components/__tests__/DonationSection.test.jsx`; `npx eslint ...`          | 3 tests passed; ESLint clean                                                          |
 | Local review for #144     | Success | `npx vitest run src/features/quiz/__tests__/MultiQuiz.test.jsx`; `npm test`; `npx eslint ...` | Targeted quiz tests passed; full suite passed with 31 files and 186 tests             |
+| Local review for #147     | Success | `npx vitest run src/components/__tests__/LanguageSwitcher.test.jsx`; `npm test`; `npm run lint`; `npm run build` | Full suite passed with 34 files and 197 tests; build prerendered 131/131 routes       |
 | Production quiz smoke     | Success | Playwright against `/en/learn/module-8/8-2/?v=962ebab`                                        | Start Challenge, focus first answer, ArrowDown focus move, Space selection all worked |
-| Production public entries | Success | Homepage, `/llms.txt`, and `/ai/manifest.json` returned HTTP 200 after #141 deploy            | Validated after run `25948710891`                                                     |
+| Language switcher smoke   | Success | Local preview browser check against `/en/dashboard` and mobile 390px `/en`                   | Active state and route-preserving language switch both worked                         |
+| Production public entries | Success | Homepage, `/llms.txt`, and `/ai/manifest.json` returned HTTP 200 after #146 deploy            | Validated after run `25954994993`                                                     |
 
 ## External Distribution
 
@@ -54,19 +58,22 @@
 
 - Stars stayed at 614; the 1000-star goal still needs external distribution and public-post execution, not only repository maintenance.
 - External MCP-list PR #544 remains `CHANGES_REQUESTED/BLOCKED`; one follow-up has now been posted, so wait for reviewer response before any further comments.
+- Open PR count is back to 1 because #147 is draft and waiting on GitHub checks; #35 remains open until that PR merges.
 - Open issue backlog is down to 8, but English proofreading issues #13/#15/#16 remain a conversion-quality risk.
 - Sponsor outreach has not been sent; the next message needs current metrics and a clear sponsor-kit link.
 
 ## Next Operating Block
 
 1. Monitor [TensorBlock/awesome-mcp-servers#544](https://github.com/TensorBlock/awesome-mcp-servers/pull/544) for reviewer response after the 2026-05-16 follow-up.
-2. Pick the next beginner-friendly issue from #35, #84, or #85, or review any new contributor PR within 24 hours.
-3. Prepare the first low-risk sponsor outreach packet for Safe, Reown, or QuickNode.
+2. Watch [#147](https://github.com/beihaili/Get-Started-with-Web3/pull/147) checks, then mark ready/merge if green to close #35.
+3. Pick the next beginner-friendly issue from #84, #85, or #34, or review any new contributor PR within 24 hours.
+4. Prepare the first low-risk sponsor outreach packet for Safe, Reown, or QuickNode.
 
 ## Evidence Links
 
 - Repository: https://github.com/beihaili/Get-Started-with-Web3
 - Production site: https://beihaili.github.io/Get-Started-with-Web3/
-- Latest merged PR: https://github.com/beihaili/Get-Started-with-Web3/pull/144
-- Latest main deploy: https://github.com/beihaili/Get-Started-with-Web3/actions/runs/25954416178
+- Latest merged PR: https://github.com/beihaili/Get-Started-with-Web3/pull/146
+- Active PR: https://github.com/beihaili/Get-Started-with-Web3/pull/147
+- Latest main deploy: https://github.com/beihaili/Get-Started-with-Web3/actions/runs/25954994993
 - External MCP-list PR: https://github.com/TensorBlock/awesome-mcp-servers/pull/544

--- a/src/components/LanguageSwitcher.jsx
+++ b/src/components/LanguageSwitcher.jsx
@@ -2,7 +2,7 @@ import { useNavigate, useLocation, useParams } from 'react-router-dom';
 import { Globe } from 'lucide-react';
 
 /**
- * Language toggle button.
+ * Compact language selector.
  * Switches between zh and en by replacing the :lang segment in the URL.
  */
 export default function LanguageSwitcher() {
@@ -10,22 +10,45 @@ export default function LanguageSwitcher() {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const toggleLang = () => {
-    const newLang = lang === 'zh' ? 'en' : 'zh';
+  const switchLang = (newLang) => {
+    if (newLang === lang) return;
     // Use regex to handle both /en/... and /en (no trailing path)
     const newPath = location.pathname.replace(new RegExp(`^/${lang}(?=/|$)`), `/${newLang}`);
     navigate(newPath);
   };
 
+  const languageOptions = [
+    { code: 'en', label: 'EN', ariaLabel: 'English' },
+    { code: 'zh', label: '\u4e2d\u6587', ariaLabel: '\u4e2d\u6587' },
+  ];
+
   return (
-    <button
-      onClick={toggleLang}
-      aria-label={lang === 'zh' ? 'Switch to English' : '切换中文'}
-      className="flex items-center gap-1 rounded-lg px-2 py-1 text-sm text-slate-400 transition-colors hover:bg-slate-800 hover:text-white"
-      title={lang === 'zh' ? 'Switch to English' : '切换中文'}
+    <div
+      role="group"
+      aria-label="Language"
+      className="inline-flex items-center gap-1 rounded-lg border border-slate-700/70 bg-slate-900/40 p-1 text-sm text-slate-400"
     >
       <Globe className="h-4 w-4" />
-      <span>{lang === 'zh' ? 'EN' : '\u4e2d\u6587'}</span>
-    </button>
+      {languageOptions.map((option) => {
+        const isActive = lang === option.code;
+
+        return (
+          <button
+            key={option.code}
+            type="button"
+            onClick={() => switchLang(option.code)}
+            aria-label={option.ariaLabel}
+            aria-pressed={isActive}
+            className={`rounded-md px-2 py-0.5 transition-colors ${
+              isActive
+                ? 'bg-cyan-500/15 text-cyan-200 ring-1 ring-cyan-400/30'
+                : 'hover:bg-slate-800 hover:text-white'
+            }`}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
   );
 }

--- a/src/components/__tests__/LanguageSwitcher.test.jsx
+++ b/src/components/__tests__/LanguageSwitcher.test.jsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import LanguageSwitcher from '../LanguageSwitcher';
+
+const routerState = vi.hoisted(() => ({
+  lang: 'en',
+  pathname: '/en',
+  navigate: vi.fn(),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ lang: routerState.lang }),
+  useLocation: () => ({ pathname: routerState.pathname }),
+  useNavigate: () => routerState.navigate,
+}));
+
+const renderLanguageSwitcher = ({ lang = 'en', pathname = '/en' } = {}) => {
+  routerState.lang = lang;
+  routerState.pathname = pathname;
+  routerState.navigate.mockClear();
+
+  return render(<LanguageSwitcher />);
+};
+
+describe('LanguageSwitcher', () => {
+  it('renders both language options and marks the current language active', () => {
+    renderLanguageSwitcher({ lang: 'en', pathname: '/en/dashboard' });
+
+    expect(screen.getByRole('group', { name: 'Language' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'English' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: '中文' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('navigates from English routes to the matching Chinese route', () => {
+    renderLanguageSwitcher({ lang: 'en', pathname: '/en/learn/module-1/1-2' });
+
+    fireEvent.click(screen.getByRole('button', { name: '中文' }));
+
+    expect(routerState.navigate).toHaveBeenCalledWith('/zh/learn/module-1/1-2');
+  });
+
+  it('navigates from Chinese routes to the matching English route', () => {
+    renderLanguageSwitcher({ lang: 'zh', pathname: '/zh/glossary' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'English' }));
+
+    expect(routerState.navigate).toHaveBeenCalledWith('/en/glossary');
+  });
+
+  it('updates root language routes without adding a trailing path', () => {
+    renderLanguageSwitcher({ lang: 'zh', pathname: '/zh' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'English' }));
+
+    expect(routerState.navigate).toHaveBeenCalledWith('/en');
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for `LanguageSwitcher` covering active language state, route-preserving language changes, and root language route switching.
- Update `LanguageSwitcher` from a single target-language toggle into a compact EN/中文 selector with `aria-pressed` active state.
- Update the 2026-05-16 operations report with the #147 validation and current KPI snapshot.

## Validation
- `npx vitest run src/components/__tests__/LanguageSwitcher.test.jsx`
- `npm test`
- `npm run lint`
- `npm run build`
- Local preview browser smoke: `/en/dashboard` -> `/zh/dashboard`, mobile 390px `/en` -> `/zh`

Closes #35