### PR TITLE
[codex] Publish lowercase README aliases for content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ npm run mcp:web3        # 启动本地 stdio MCP server
 - `scripts/generate-ai-index.mjs`: 生成上述 artifact。
 - `scripts/publish-ai-artifacts.mjs`: 将根目录 `ai/` artifacts 复制到 `public/`。
 - `scripts/verify-ai-entrypoints.mjs`: 检查 artifacts、公开 URL、MCP 工具清单、中英文覆盖和 x402 元数据。
-- `scripts/sync-content.mjs`: 将中英文课程内容复制到 `public/content/`，为英文课程补齐对应中文课程中存在但英文目录缺失的本地图片资产，并生成 `public/content/image-metadata.json`，供课程图片渲染时补充 `width` / `height`。
+- `scripts/sync-content.mjs`: 将中英文课程内容复制到 `public/content/`，为源目录中的 `README.MD` 生成发布用规范别名 `README.md`，为英文课程补齐对应中文课程中存在但英文目录缺失的本地图片资产，并生成 `public/content/image-metadata.json`，供课程图片渲染时补充 `width` / `height`。
 - `scripts/check-translation-coverage.mjs`: 非阻塞检查 `zh/` 中缺失的英文翻译，支持 `README.md` 和 `README.MD` 两种文件名。
 - `scripts/ai-content-core.mjs`: 搜索、读取课程、生成学习路径、组合上下文等纯函数。
 

--- a/scripts/__tests__/sync-content.test.js
+++ b/scripts/__tests__/sync-content.test.js
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { Buffer } from 'node:buffer';
 import os from 'node:os';
 import path from 'node:path';
@@ -86,6 +86,42 @@ describe('sync-content', () => {
         'utf8'
       )
     ).resolves.toContain('English');
+  });
+
+  it('publishes canonical README.md aliases for uppercase source readmes', async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'web3-sync-content-'));
+    const lessonDir = path.join(tempDir, 'zh', 'Web3QuickStart', '01_FirstWeb3Identity');
+    await mkdir(lessonDir, { recursive: true });
+    await writeFile(path.join(lessonDir, 'README.MD'), '# 中文大写 README\n', 'utf8');
+
+    await syncContent({
+      projectRoot: tempDir,
+      courseData: [
+        {
+          lessons: [{ path: 'Web3QuickStart/01_FirstWeb3Identity' }],
+        },
+      ],
+      logger: { log() {}, warn() {}, error() {} },
+    });
+
+    const publishedDir = path.join(
+      tempDir,
+      'public',
+      'content',
+      'zh',
+      'Web3QuickStart',
+      '01_FirstWeb3Identity'
+    );
+
+    await expect(readFile(path.join(publishedDir, 'README.md'), 'utf8')).resolves.toContain(
+      '中文大写 README'
+    );
+
+    if (await supportsCaseDistinctReadmes(tempDir)) {
+      await expect(readdir(publishedDir)).resolves.toEqual(
+        expect.arrayContaining(['README.MD', 'README.md'])
+      );
+    }
   });
 
   it('writes image dimension metadata for copied lesson images', async () => {
@@ -176,4 +212,14 @@ const createPngHeader = (width, height) => {
   buffer.writeUInt32BE(width, 16);
   buffer.writeUInt32BE(height, 20);
   return buffer;
+};
+
+const supportsCaseDistinctReadmes = async (root) => {
+  const probeDir = path.join(root, 'case-probe');
+  await mkdir(probeDir, { recursive: true });
+  await writeFile(path.join(probeDir, 'README.MD'), 'upper', 'utf8');
+  await writeFile(path.join(probeDir, 'README.md'), 'lower', 'utf8');
+  const entries = await readdir(probeDir);
+
+  return entries.includes('README.MD') && entries.includes('README.md');
 };

--- a/scripts/sync-content.mjs
+++ b/scripts/sync-content.mjs
@@ -14,6 +14,7 @@ const ensureExists = async (dir) => {
 
 const IMAGE_EXTENSIONS = new Set(['.gif', '.jpeg', '.jpg', '.png']);
 const IMAGE_METADATA_FILE = 'image-metadata.json';
+const CANONICAL_README_FILE = 'README.md';
 const README_FILE_PATTERN = /^README\.md$/i;
 
 const isImageFile = (filePath) => IMAGE_EXTENSIONS.has(path.extname(filePath).toLowerCase());
@@ -217,6 +218,39 @@ const copyMissingReferencedImages = async (fallbackFolder, targetFolder, logger 
   await visit(targetFolder);
 };
 
+const ensureCanonicalReadmeAliases = async (targetFolder, logger = console) => {
+  const visit = async (dir) => {
+    const entries = await readdir(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const entryPath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        await visit(entryPath);
+        continue;
+      }
+
+      if (
+        !entry.isFile() ||
+        !README_FILE_PATTERN.test(entry.name) ||
+        entry.name === CANONICAL_README_FILE
+      ) {
+        continue;
+      }
+
+      const canonicalPath = path.join(dir, CANONICAL_README_FILE);
+      if (existsSync(canonicalPath)) {
+        continue;
+      }
+
+      await cp(entryPath, canonicalPath);
+      logger.log(`[sync-content] Added canonical README alias ${entryPath} -> ${canonicalPath}`);
+    }
+  };
+
+  await visit(targetFolder);
+};
+
 export const getSourceFoldersFromCourseData = (courseData = COURSE_DATA) => {
   const folders = new Set();
 
@@ -246,17 +280,18 @@ const safeCopy = async (source, destination, logger = console) => {
     const statResult = await stat(source);
     if (!statResult.isDirectory()) {
       logger.warn(`[sync-content] Skip ${source}: not a directory`);
-      return;
+      return false;
     }
   } catch (error) {
     logger.warn(`[sync-content] Skip ${source}: ${error.message}`);
-    return;
+    return false;
   }
 
   await ensureExists(path.dirname(destination));
   await rm(destination, { recursive: true, force: true });
   await cp(source, destination, { recursive: true });
   logger.log(`[sync-content] Copied ${source} -> ${destination}`);
+  return true;
 };
 
 export const syncContent = async (options = {}) => {
@@ -270,7 +305,9 @@ export const syncContent = async (options = {}) => {
   for (const folder of sourceFolders) {
     const src = path.join(root, 'zh', folder);
     const dest = path.join(contentRoot, 'zh', folder);
-    await safeCopy(src, dest, logger);
+    if (await safeCopy(src, dest, logger)) {
+      await ensureCanonicalReadmeAliases(dest, logger);
+    }
   }
 
   // Sync en/ folders (skip silently if source doesn't exist)
@@ -280,9 +317,9 @@ export const syncContent = async (options = {}) => {
   for (const folder of sourceFolders) {
     const src = path.join(enSource, folder);
     const dest = path.join(enTarget, folder);
-    if (existsSync(src)) {
-      await safeCopy(src, dest, logger);
+    if (existsSync(src) && (await safeCopy(src, dest, logger))) {
       await copyMissingReferencedImages(path.join(root, 'zh', folder), dest, logger);
+      await ensureCanonicalReadmeAliases(dest, logger);
     }
   }
 


### PR DESCRIPTION
Summary
- Add canonical README.md aliases when sync-content publishes source lessons that use README.MD.
- Keep existing source filenames intact while avoiding case-sensitive GitHub Pages 404s for runtime content fetches.
- Cover the alias behavior in sync-content tests and document it in AGENTS.md.

Validation
- npx vitest run scripts/__tests__/sync-content.test.js
- npm test
- npm run lint
- npm run build
- npm run ai:verify
- node scripts/check-translation-coverage.mjs (exit 0; existing 17 missing-English warnings)

Follow-up to #148 production smoke finding.