### PR TITLE
[codex] Record interactive learning release

### DIFF
--- a/docs/operations/2026-05-18-daily-report.md
+++ b/docs/operations/2026-05-18-daily-report.md
@@ -1,0 +1,72 @@
+# Get Started with Web3 Daily Operations Report
+
+**Date:** 2026-05-18
+**Owner:** beihai + Codex
+**Reporting window:** 2026-05-18 08:37 CST snapshot; GitHub timestamps are UTC unless noted.
+
+## KPI Snapshot
+
+| Metric       | Current | Previous / Baseline | Movement | Source                                        |
+| ------------ | ------: | ------------------: | -------: | --------------------------------------------- |
+| GitHub stars |     614 |                 614 |        0 | `gh repo view beihaili/Get-Started-with-Web3` |
+| Forks        |      55 |                  55 |        0 | `gh repo view beihaili/Get-Started-with-Web3` |
+| Watchers     |       3 |                   3 |        0 | `gh repo view beihaili/Get-Started-with-Web3` |
+| Open PRs     |       0 |                   0 |        0 | `gh pr list --state open`                     |
+| Open issues  |       5 |                   5 |        0 | `gh issue list --state open --limit 200`      |
+
+## Completed
+
+- External distribution: published a GitHub Release for the interactive learning update: Merkle Tree Builder plus EIP-1559 Gas Fee Calculator.
+- Public post queue: added reusable X/Farcaster, Chinese community, and short-form product update copy anchored to the release link.
+- Distribution tracker: marked GitHub Release as published and moved Twitter/X plus learnblockchain.cn/community targets to ready-to-publish status.
+- Operations hygiene: started the 2026-05-18 daily report with current metrics, release evidence, and next operating block.
+
+## Deploy And Verification
+
+| Surface                  | Status  | Evidence                                                                                                                          | Notes                                                               |
+| ------------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Latest production deploy | Success | [Run 25987625216](https://github.com/beihaili/Get-Started-with-Web3/actions/runs/25987625216)                                     | `docs: update 2026-05-17 operations report` completed on main       |
+| Release publication      | Success | [interactive-learning-2026-05-18](https://github.com/beihaili/Get-Started-with-Web3/releases/tag/interactive-learning-2026-05-18) | Public GitHub product update published at 614 stars                 |
+| Production smoke         | Success | `/en/learn/module-11/11-2` and `/zh/.../11-2`                                                                                     | Gas calculator rendered after latest Pages deploy; bad responses: 0 |
+| Formatting               | Success | `npx prettier --check`                                                                                                            | Public post, tracker, and daily report Markdown use Prettier style  |
+| Whitespace               | Success | `git diff --check`                                                                                                                | No whitespace errors                                                |
+
+## External Distribution
+
+| Target                            | Status               | Evidence                                                                                       | Next action                                                            |
+| --------------------------------- | -------------------- | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| GitHub Release                    | Published            | https://github.com/beihaili/Get-Started-with-Web3/releases/tag/interactive-learning-2026-05-18 | Track release views/stars if GitHub exposes useful engagement          |
+| Twitter/X thread                  | Ready                | `docs/strategy/2026-05-15-public-post-drafts.md`                                               | Publish Draft 3 from beihai account                                    |
+| learnblockchain.cn/community      | Ready                | `docs/strategy/2026-05-15-public-post-drafts.md`                                               | Publish Chinese community post when convenient                         |
+| TensorBlock `awesome-mcp-servers` | Waiting for reviewer | [PR #544](https://github.com/TensorBlock/awesome-mcp-servers/pull/544)                         | Avoid repeat pings until reviewer responds to the 2026-05-16 follow-up |
+
+## Sponsor And Revenue
+
+| Lead / Channel            | Status | Next action                                                                          | Risk notes                                        |
+| ------------------------- | ------ | ------------------------------------------------------------------------------------ | ------------------------------------------------- |
+| Safe Ecosystem Foundation | Queued | Convert interactive smart-account and gas-fee work into a grant-style impact memo    | Low trust risk; education aligned                 |
+| Reown / WalletConnect     | Queued | Personalize wallet UX and connection-safety outreach around beginner-safe onboarding | Avoid implying wallet endorsement                 |
+| QuickNode                 | Queued | Personalize infrastructure sponsor outreach around RPC and builder lessons           | Do not promise developer acquisition numbers yet  |
+| Exchanges / affiliate     | Hold   | Requires explicit trust-policy review before contact                                 | High trust risk; user confirmation still required |
+
+## Blockers And Risks
+
+- Growth is still flat at 614 stars; distribution must now move from prepared copy to actually published posts.
+- GitHub Discussions are disabled, so GitHub-native community updates currently need to use Releases, Issues, PR comments, or README/docs.
+- Translation coverage still reports 17 missing-English warnings; the visible contributor backlog remains useful but incomplete.
+- Sponsor outreach has not been sent; use the interactive-learning release as the next credible proof point.
+
+## Next Operating Block
+
+1. Publish the Draft 3 X/Farcaster thread and Chinese community post, then record links and visible metrics.
+2. Prepare a one-page Safe/Reown sponsor or grant memo using the interactive learning release as evidence.
+3. Start [#34](https://github.com/beihaili/Get-Started-with-Web3/issues/34) or reshape it into a contributor-friendly code-example issue.
+
+## Evidence Links
+
+- Repository: https://github.com/beihaili/Get-Started-with-Web3
+- Production site: https://beihaili.github.io/Get-Started-with-Web3/
+- Interactive learning release: https://github.com/beihaili/Get-Started-with-Web3/releases/tag/interactive-learning-2026-05-18
+- Merkle feature PR: https://github.com/beihaili/Get-Started-with-Web3/pull/148
+- Gas fee calculator PR: https://github.com/beihaili/Get-Started-with-Web3/pull/151
+- Latest main deploy: https://github.com/beihaili/Get-Started-with-Web3/actions/runs/25987625216

--- a/docs/strategy/2026-05-14-awesome-list-submissions.md
+++ b/docs/strategy/2026-05-14-awesome-list-submissions.md
@@ -45,8 +45,9 @@ Do not submit to spammy lists, paid-only lists, or repositories with no recent m
 | awesome-mcp                  | MCP               | Read-only Web3 curriculum MCP             | Submitted   | Track TensorBlock/awesome-mcp-servers#544   |
 | awesome-llms-txt             | AI agent content  | Public `llms.txt` entrypoint              | Not started | Check if education repos are accepted       |
 | awesome-ai-agents            | AI agents         | Agent-readable curriculum                 | Not started | Check if MCP resources are accepted         |
-| learnblockchain.cn/community | Chinese community | Existing referrer and strong audience fit | Drafted     | Publish from public post draft queue        |
-| Twitter/X thread             | Personal brand    | Fastest direct distribution               | Drafted     | Publish from public post draft queue        |
+| GitHub Release               | Product update    | Low-risk public update for watchers       | Published   | Track release engagement                    |
+| learnblockchain.cn/community | Chinese community | Existing referrer and strong audience fit | Ready       | Publish interactive-learning update draft   |
+| Twitter/X thread             | Personal brand    | Fastest direct distribution               | Ready       | Publish interactive-learning update thread  |
 
 ## Pull Request Template For Awesome Lists
 
@@ -86,7 +87,8 @@ GitHub: https://github.com/beihaili/Get-Started-with-Web3
 
 ## Submission Log
 
-| Date       | Target                          | Link                                                        | Status    | Notes                                                                                                           |
-| ---------- | ------------------------------- | ----------------------------------------------------------- | --------- | --------------------------------------------------------------------------------------------------------------- |
-| 2026-05-14 | useWeb3/awesome-web3            | https://github.com/useWeb3/awesome-web3/pull/6              | Closed    | Added Get Started with Web3 to Courses. Closed by maintainer without comment. Repo stars at submission: 614.    |
-| 2026-05-14 | TensorBlock/awesome-mcp-servers | https://github.com/TensorBlock/awesome-mcp-servers/pull/544 | Submitted | Added the read-only Web3 curriculum MCP server to Knowledge Management & Memory. Repo stars at submission: 614. |
+| Date       | Target                          | Link                                                                                           | Status    | Notes                                                                                                           |
+| ---------- | ------------------------------- | ---------------------------------------------------------------------------------------------- | --------- | --------------------------------------------------------------------------------------------------------------- |
+| 2026-05-14 | useWeb3/awesome-web3            | https://github.com/useWeb3/awesome-web3/pull/6                                                 | Closed    | Added Get Started with Web3 to Courses. Closed by maintainer without comment. Repo stars at submission: 614.    |
+| 2026-05-14 | TensorBlock/awesome-mcp-servers | https://github.com/TensorBlock/awesome-mcp-servers/pull/544                                    | Submitted | Added the read-only Web3 curriculum MCP server to Knowledge Management & Memory. Repo stars at submission: 614. |
+| 2026-05-18 | GitHub Release                  | https://github.com/beihaili/Get-Started-with-Web3/releases/tag/interactive-learning-2026-05-18 | Published | Released Merkle Tree Builder and EIP-1559 Gas Fee Calculator product update. Repo stars at publication: 614.    |

--- a/docs/strategy/2026-05-15-public-post-drafts.md
+++ b/docs/strategy/2026-05-15-public-post-drafts.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-05-15
 **Owner:** beihai + Codex
-**Status:** Ready for maintainer review and publishing
+**Status:** Ready for publishing; GitHub release published on 2026-05-18
 
 ## Publishing Rules
 
@@ -65,7 +65,83 @@ https://github.com/beihaili/Get-Started-with-Web3
 Open to contributors for translations, source links, safety notes, examples, and beginner-friendly issue fixes.
 ```
 
+## Draft 3: Interactive Learning Update
+
+**Target channel:** Twitter/X, Farcaster, GitHub social preview, Chinese Web3 communities.
+**Audience:** Web3 learners, educators, open-source builders, and AI-agent developers.
+**Concrete learner outcome:** A learner can manipulate two core Web3 concepts directly: Bitcoin Merkle roots and EIP-1559 gas-fee estimation.
+**Status:** GitHub Release published; social/community posts ready.
+**Canonical release:** https://github.com/beihaili/Get-Started-with-Web3/releases/tag/interactive-learning-2026-05-18
+
+### X / Farcaster Thread
+
+```markdown
+1/ New Get Started with Web3 update:
+
+The curriculum now has two hands-on interactive lessons:
+
+- Bitcoin Merkle Tree Builder
+- EIP-1559 Gas Fee Calculator
+
+Instead of only reading about the concepts, learners can manipulate them directly.
+
+2/ Merkle Tree Builder:
+
+Type transaction-like values, hash leaves with SHA-256, duplicate odd nodes, combine pairs, and inspect the Merkle root step by step.
+
+Lesson:
+https://beihaili.github.io/Get-Started-with-Web3/en/learn/module-2/2-1
+
+3/ Gas Fee Calculator:
+
+Change gas limit, priority tip, and max fee cap to see how EIP-1559 turns them into an effective gas price and total ETH/USD estimate.
+
+Lesson:
+https://beihaili.github.io/Get-Started-with-Web3/en/learn/module-11/11-2
+
+4/ Both are bilingual, tested, and available in the open-source repo.
+
+The broader goal is to turn a Web3 notes repo into a safer, AI-native learning platform: lessons, quizzes, badges, llms.txt, content index, and a read-only MCP server.
+
+Release:
+https://github.com/beihaili/Get-Started-with-Web3/releases/tag/interactive-learning-2026-05-18
+```
+
+### Chinese Community Post
+
+```markdown
+Get Started with Web3 今天更新了两个互动学习组件：
+
+1. Bitcoin Merkle Tree Builder：输入交易内容，逐层计算 SHA-256 hash，观察奇数节点复制、父节点组合和 Merkle Root 生成过程。
+2. EIP-1559 Gas Fee Calculator：修改 Gas 上限、优先小费和最大费用上限，直接看到有效 Gas 价格、ETH 成本和美元估算。
+
+这两个组件都已经嵌入中英文课程，并有测试覆盖。目标是让 Web3 学习从“读概念”继续往“能动手理解概念”推进。
+
+在线学习：
+https://beihaili.github.io/Get-Started-with-Web3/zh
+
+Release：
+https://github.com/beihaili/Get-Started-with-Web3/releases/tag/interactive-learning-2026-05-18
+
+项目不会提供交易建议，也不推广任何 token。如果你正在系统学习 Web3，欢迎 star、提 issue、校对翻译或补充代码示例。
+```
+
+### Short Single-Post Version
+
+```markdown
+Get Started with Web3 now has two interactive lessons:
+
+- Bitcoin Merkle Tree Builder
+- EIP-1559 Gas Fee Calculator
+
+The direction is simple: make Web3 concepts learnable by manipulating them, not only reading about them.
+
+Release: https://github.com/beihaili/Get-Started-with-Web3/releases/tag/interactive-learning-2026-05-18
+Site: https://beihaili.github.io/Get-Started-with-Web3/
+```
+
 ## Publication Log
 
-| Date | Channel | Link | Status | Visible Metrics | Notes |
-| ---- | ------- | ---- | ------ | --------------- | ----- |
+| Date       | Channel        | Link                                                                                           | Status    | Visible Metrics          | Notes                                                                   |
+| ---------- | -------------- | ---------------------------------------------------------------------------------------------- | --------- | ------------------------ | ----------------------------------------------------------------------- |
+| 2026-05-18 | GitHub Release | https://github.com/beihaili/Get-Started-with-Web3/releases/tag/interactive-learning-2026-05-18 | Published | 614 stars at publication | Product update for Merkle Tree Builder and EIP-1559 Gas Fee Calculator. |


### PR DESCRIPTION
## Summary
- Publish and record the 2026-05-18 interactive learning GitHub Release.
- Add ready-to-publish X/Farcaster, Chinese community, and short-form post copy for the Merkle Builder + Gas Fee Calculator update.
- Start the 2026-05-18 daily operations report with current metrics, distribution status, and next actions.

## Validation
- `npx prettier --check docs/strategy/2026-05-15-public-post-drafts.md docs/strategy/2026-05-14-awesome-list-submissions.md docs/operations/2026-05-18-daily-report.md`
- `git diff --check`

External action executed:
- GitHub Release: https://github.com/beihaili/Get-Started-with-Web3/releases/tag/interactive-learning-2026-05-18
