### PR TITLE
docs: add MCP client setup snippet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ npm run mcp:web3        # 启动本地 stdio MCP server
 
 ## AI-Native 内容层
 
-- `ai/manifest.json`: 服务清单，包含仓库信息、artifact 路径、MCP 命令和未来 x402 工具元数据。
+- `ai/manifest.json`: 服务清单，包含仓库信息、artifact 路径、MCP 命令、可复制的 `mcpServers` client config 示例和未来 x402 工具元数据。
 - `ai/content-index.json`: 双语课程和术语表索引，供 Agent 搜索、引用和组合上下文。
 - `ai/llms.txt`: 面向 Agent/crawler 的文本入口。
 - `public/llms.txt`: GitHub Pages 根路径公开入口，部署后为 `https://beihaili.github.io/Get-Started-with-Web3/llms.txt`。

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If this repo helps you learn or teach Web3, please [star the project](https://gi
 | Course modules  | 11 modules                                                                    |
 | Lessons         | 58 lessons in the React course map                                            |
 | AI-native index | 106 indexed bilingual lesson entries                                          |
-| Glossary        | 45 Web3 terms                                                                 |
+| Glossary        | 55 Web3 terms                                                                 |
 | Languages       | Chinese first, English in progress                                            |
 | App features    | AI Tutor, search, quizzes, badges, XP, dark/light mode, PWA/offline support   |
 | Agent surfaces  | `llms.txt`, AI manifest, content index, local read-only MCP server            |
@@ -119,6 +119,20 @@ Example agent workflow:
 
 ```bash
 npm run mcp:web3
+```
+
+For MCP clients that accept an `mcpServers` JSON block, copy this config and replace `cwd` with your local repository path:
+
+```json
+{
+  "mcpServers": {
+    "get-started-with-web3": {
+      "command": "npm",
+      "args": ["run", "mcp:web3"],
+      "cwd": "/absolute/path/to/Get-Started-with-Web3"
+    }
+  }
+}
 ```
 
 Then connect an MCP client and use:

--- a/README.zh.md
+++ b/README.zh.md
@@ -50,7 +50,7 @@ Web3 的学习资料长期分散在钱包教程、协议文档、安全提醒、
 | 课程模块       | 11 个                                                  |
 | React 课程地图 | 58 讲                                                  |
 | AI-native 索引 | 106 条双语课程索引记录                                 |
-| 术语表         | 45 个 Web3 术语                                        |
+| 术语表         | 55 个 Web3 术语                                        |
 | 语言           | 中文优先，英文持续补齐                                 |
 | App 功能       | AI Tutor、搜索、测验、徽章、XP、深浅色模式、PWA/离线   |
 | Agent 入口     | `llms.txt`、AI manifest、内容索引、本地只读 MCP server |
@@ -119,6 +119,20 @@ Agent 使用方式：
 
 ```bash
 npm run mcp:web3
+```
+
+如果你的 MCP client 支持 `mcpServers` JSON 配置，可以复制下面的配置，并把 `cwd` 替换成本仓库的本地绝对路径：
+
+```json
+{
+  "mcpServers": {
+    "get-started-with-web3": {
+      "command": "npm",
+      "args": ["run", "mcp:web3"],
+      "cwd": "/absolute/path/to/Get-Started-with-Web3"
+    }
+  }
+}
 ```
 
 然后在 MCP client 中调用：

--- a/ai/content-index.json
+++ b/ai/content-index.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2026-05-09",
-  "generatedAt": "2026-05-18T01:31:48.414Z",
+  "generatedAt": "2026-05-18T02:25:30.191Z",
   "repository": {
     "name": "Get-Started-with-Web3",
     "owner": "beihaili",

--- a/ai/llms.txt
+++ b/ai/llms.txt
@@ -4,7 +4,7 @@ This repository exposes bilingual Web3 learning content for AI agents.
 
 Source: https://github.com/beihaili/Get-Started-with-Web3
 Homepage: https://beihaili.github.io/Get-Started-with-Web3/
-Generated: 2026-05-18T01:31:48.414Z
+Generated: 2026-05-18T02:25:30.191Z
 
 ## Artifacts
 - Manifest: ai/manifest.json
@@ -14,6 +14,21 @@ Generated: 2026-05-18T01:31:48.414Z
 - Command: npm run mcp:web3
 - Transport: stdio
 - Mode: read-only
+- Client config: replace cwd before use.
+```json
+{
+  "mcpServers": {
+    "get-started-with-web3": {
+      "command": "npm",
+      "args": [
+        "run",
+        "mcp:web3"
+      ],
+      "cwd": "/absolute/path/to/Get-Started-with-Web3"
+    }
+  }
+}
+```
 
 ## Tools
 - search_web3_content: Search lesson titles, headings, excerpts, and glossary definitions. (free)

--- a/ai/manifest.json
+++ b/ai/manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2026-05-09",
-  "generatedAt": "2026-05-18T01:31:48.414Z",
+  "generatedAt": "2026-05-18T02:25:30.191Z",
   "repository": {
     "name": "Get-Started-with-Web3",
     "owner": "beihaili",
@@ -29,7 +29,17 @@
   "mcp": {
     "command": "npm run mcp:web3",
     "transport": "stdio",
-    "readOnly": true
+    "readOnly": true,
+    "clientConfig": {
+      "mcpServers": {
+        "get-started-with-web3": {
+          "command": "npm",
+          "args": ["run", "mcp:web3"],
+          "cwd": "/absolute/path/to/Get-Started-with-Web3"
+        }
+      }
+    },
+    "clientConfigNote": "Replace cwd with your local repository path before pasting this into an MCP client that supports mcpServers JSON."
   },
   "tools": [
     {

--- a/docs/operations/2026-05-18-daily-report.md
+++ b/docs/operations/2026-05-18-daily-report.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-05-18
 **Owner:** beihai + Codex
-**Reporting window:** 2026-05-18 10:01 CST snapshot; GitHub timestamps are UTC unless noted.
+**Reporting window:** 2026-05-18 10:25 CST snapshot; GitHub timestamps are UTC unless noted.
 
 ## KPI Snapshot
 
@@ -26,6 +26,7 @@
 - Community: created and pinned the public 1000-star roadmap issue [#156](https://github.com/beihaili/Get-Started-with-Web3/issues/156).
 - Community: seeded six new contributor-ready good-first issues [#157](https://github.com/beihaili/Get-Started-with-Web3/issues/157)-[#162](https://github.com/beihaili/Get-Started-with-Web3/issues/162), bringing the open good-first issue queue to 10.
 - Community infrastructure: updated issue templates to request expected files, definition of done, and good-first-issue suitability.
+- AI-native productization: added a copy-paste MCP client configuration snippet to both READMEs and generated AI artifacts, and corrected README glossary count to 55.
 - Operations hygiene: started the 2026-05-18 daily report with current metrics, release evidence, and next operating block.
 
 ## Deploy And Verification
@@ -38,6 +39,7 @@
 | Sponsor memo             | Drafted | `docs/strategy/2026-05-18-safe-reown-impact-memo.md`                                                                                                                                                            | No outreach sent yet                                                |
 | Content verification     | Success | `npm test`, `npm run lint`, `npm run ai:verify`, `npm run build`                                                                                                                                                | Bitcoin Script examples and regenerated AI artifacts validated      |
 | Community backlog        | Success | [#156](https://github.com/beihaili/Get-Started-with-Web3/issues/156), [#157](https://github.com/beihaili/Get-Started-with-Web3/issues/157)-[#162](https://github.com/beihaili/Get-Started-with-Web3/issues/162) | Public roadmap pinned; 10 open good-first issues active             |
+| AI-native setup          | Success | `README.md`, `README.zh.md`, `ai/llms.txt`, `ai/manifest.json`                                                                                                                                                  | MCP client config snippet added; local AI verification passed       |
 | Formatting               | Success | `npx prettier --check`                                                                                                                                                                                          | Public post, tracker, and daily report Markdown use Prettier style  |
 | Whitespace               | Success | `git diff --check`                                                                                                                                                                                              | No whitespace errors                                                |
 
@@ -72,6 +74,7 @@
 1. Publish the Draft 3 X/Farcaster thread and Chinese community post, then record links and visible metrics.
 2. Send the Safe or Reown memo through the chosen channel, then record the sent link/date and any reply.
 3. Draft the monthly contributor spotlight template and keep the pinned roadmap updated as issues close.
+4. Draft landing copy for `generate_personalized_web3_plan` and `audit_learning_answer`.
 
 ## Evidence Links
 

--- a/docs/strategy/2026-05-14-execution-board.md
+++ b/docs/strategy/2026-05-14-execution-board.md
@@ -71,7 +71,7 @@ Update weekly.
 **Outcome:** The project has a differentiated story and a path to paid tools.
 
 - [x] Add a README quick demo showing how an agent can use `npm run mcp:web3`.
-- [ ] Add one copy-paste MCP client setup snippet if practical.
+- [x] Add one copy-paste MCP client setup snippet in README and AI artifacts.
 - [ ] Draft landing copy for `generate_personalized_web3_plan` and `audit_learning_answer`.
 - [ ] Decide whether Phase 1 paid tool should be x402, Stripe, GitHub Sponsors gated, or manual payment.
 - [ ] Keep local MCP free and clearly marked read-only.

--- a/public/ai/content-index.json
+++ b/public/ai/content-index.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2026-05-09",
-  "generatedAt": "2026-05-18T01:31:48.414Z",
+  "generatedAt": "2026-05-18T02:25:30.191Z",
   "repository": {
     "name": "Get-Started-with-Web3",
     "owner": "beihaili",

--- a/public/ai/manifest.json
+++ b/public/ai/manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2026-05-09",
-  "generatedAt": "2026-05-18T01:31:48.414Z",
+  "generatedAt": "2026-05-18T02:25:30.191Z",
   "repository": {
     "name": "Get-Started-with-Web3",
     "owner": "beihaili",
@@ -29,7 +29,17 @@
   "mcp": {
     "command": "npm run mcp:web3",
     "transport": "stdio",
-    "readOnly": true
+    "readOnly": true,
+    "clientConfig": {
+      "mcpServers": {
+        "get-started-with-web3": {
+          "command": "npm",
+          "args": ["run", "mcp:web3"],
+          "cwd": "/absolute/path/to/Get-Started-with-Web3"
+        }
+      }
+    },
+    "clientConfigNote": "Replace cwd with your local repository path before pasting this into an MCP client that supports mcpServers JSON."
   },
   "tools": [
     {

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -4,7 +4,7 @@ This repository exposes bilingual Web3 learning content for AI agents.
 
 Source: https://github.com/beihaili/Get-Started-with-Web3
 Homepage: https://beihaili.github.io/Get-Started-with-Web3/
-Generated: 2026-05-18T01:31:48.414Z
+Generated: 2026-05-18T02:25:30.191Z
 
 ## Artifacts
 - Manifest: ai/manifest.json
@@ -14,6 +14,21 @@ Generated: 2026-05-18T01:31:48.414Z
 - Command: npm run mcp:web3
 - Transport: stdio
 - Mode: read-only
+- Client config: replace cwd before use.
+```json
+{
+  "mcpServers": {
+    "get-started-with-web3": {
+      "command": "npm",
+      "args": [
+        "run",
+        "mcp:web3"
+      ],
+      "cwd": "/absolute/path/to/Get-Started-with-Web3"
+    }
+  }
+}
+```
 
 ## Tools
 - search_web3_content: Search lesson titles, headings, excerpts, and glossary definitions. (free)

--- a/scripts/__tests__/generate-ai-index.test.js
+++ b/scripts/__tests__/generate-ai-index.test.js
@@ -42,8 +42,14 @@ describe('generate-ai-index', () => {
 
     expect(manifest.counts.modules).toBe(11);
     expect(manifest.mcp.command).toBe('npm run mcp:web3');
+    expect(manifest.mcp.clientConfig.mcpServers['get-started-with-web3']).toMatchObject({
+      command: 'npm',
+      args: ['run', 'mcp:web3'],
+      cwd: '/absolute/path/to/Get-Started-with-Web3',
+    });
     expect(contentIndex.lessons.length).toBeGreaterThan(40);
     expect(llmsTxt).toContain('Get Started With Web3 AI Index');
+    expect(llmsTxt).toContain('"get-started-with-web3"');
     expect(llmsTxt).not.toMatch(/TBD|TODO|placeholder/i);
   });
 });

--- a/scripts/ai-content-core.mjs
+++ b/scripts/ai-content-core.mjs
@@ -2,7 +2,12 @@ import { readdirSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { GLOSSARY_DATA } from '../src/config/glossaryData.js';
-import { COURSE_DATA, GITHUB_BRANCH, GITHUB_REPO, GITHUB_USERNAME } from '../src/config/courseData.js';
+import {
+  COURSE_DATA,
+  GITHUB_BRANCH,
+  GITHUB_REPO,
+  GITHUB_USERNAME,
+} from '../src/config/courseData.js';
 
 export const AI_SCHEMA_VERSION = '2026-05-09';
 export const LANGUAGES = ['zh', 'en'];
@@ -12,6 +17,16 @@ export const PUBLIC_AI_ENTRYPOINTS = {
   llmsTxt: `${SITE_BASE_URL}/llms.txt`,
   manifest: `${SITE_BASE_URL}/ai/manifest.json`,
   contentIndex: `${SITE_BASE_URL}/ai/content-index.json`,
+};
+
+export const LOCAL_MCP_CLIENT_CONFIG = {
+  mcpServers: {
+    'get-started-with-web3': {
+      command: 'npm',
+      args: ['run', 'mcp:web3'],
+      cwd: '/absolute/path/to/Get-Started-with-Web3',
+    },
+  },
 };
 
 const DEFAULT_PROJECT_ROOT = path.resolve(process.cwd());
@@ -33,7 +48,8 @@ const TOOL_CATALOG = [
   {
     name: 'get_learning_path',
     title: 'Get Learning Path',
-    description: 'Return role-based learning paths for beginners, builders, researchers, and investors.',
+    description:
+      'Return role-based learning paths for beginners, builders, researchers, and investors.',
     x402: { enabled: false },
   },
   {
@@ -155,7 +171,10 @@ export async function buildAiIndex(options = {}) {
         labUrl: lesson.labUrl || null,
         availability,
         siteUrls: Object.fromEntries(
-          LANGUAGES.map((lang) => [lang, `${SITE_BASE_URL}/${lang}/learn/${module.id}/${lesson.id}`])
+          LANGUAGES.map((lang) => [
+            lang,
+            `${SITE_BASE_URL}/${lang}/learn/${module.id}/${lesson.id}`,
+          ])
         ),
       });
     }
@@ -256,7 +275,9 @@ export async function readLesson(index, options = {}) {
   const lesson = findIndexedLesson(index, { ...options, lang });
 
   if (!lesson) {
-    throw new Error(`Lesson not found for lang=${lang}, moduleId=${options.moduleId || ''}, lessonId=${options.lessonId || ''}, path=${options.path || ''}`);
+    throw new Error(
+      `Lesson not found for lang=${lang}, moduleId=${options.moduleId || ''}, lessonId=${options.lessonId || ''}, path=${options.path || ''}`
+    );
   }
 
   const absolutePath = path.join(index.projectRoot || DEFAULT_PROJECT_ROOT, lesson.sourcePath);
@@ -322,7 +343,8 @@ export async function composeContext(index, options = {}) {
   let usedChars = 0;
 
   for (const result of search.results) {
-    const title = result.type === 'lesson' ? `${result.moduleTitle} / ${result.title}` : result.term;
+    const title =
+      result.type === 'lesson' ? `${result.moduleTitle} / ${result.title}` : result.term;
     const body = result.type === 'lesson' ? result.excerpt : result.definition;
     const citation = result.citation;
     const block = `## ${title}\n${body}\nCitation: ${citation.file}`;
@@ -367,6 +389,9 @@ export function createManifest(index) {
       command: 'npm run mcp:web3',
       transport: 'stdio',
       readOnly: true,
+      clientConfig: LOCAL_MCP_CLIENT_CONFIG,
+      clientConfigNote:
+        'Replace cwd with your local repository path before pasting this into an MCP client that supports mcpServers JSON.',
     },
     tools: index.tools,
   };
@@ -391,10 +416,16 @@ export function createLlmsTxt(index) {
     '- Command: npm run mcp:web3',
     '- Transport: stdio',
     '- Mode: read-only',
+    '- Client config: replace cwd before use.',
+    '```json',
+    JSON.stringify(LOCAL_MCP_CLIENT_CONFIG, null, 2),
+    '```',
     '',
     '## Tools',
     ...index.tools.map((tool) => {
-      const price = tool.x402.enabled ? `future x402 $${tool.x402.priceUsd} on ${tool.x402.network}` : 'free';
+      const price = tool.x402.enabled
+        ? `future x402 $${tool.x402.priceUsd} on ${tool.x402.network}`
+        : 'free';
       return `- ${tool.name}: ${tool.description} (${price})`;
     }),
     '',


### PR DESCRIPTION
## Summary
- Add copy-paste `mcpServers` config to English and Chinese READMEs
- Expose the same local MCP client config in generated AI manifest and llms.txt artifacts
- Correct README glossary count to 55 and update operations/strategy notes

## Verification
- npx vitest run scripts/__tests__/generate-ai-index.test.js scripts/__tests__/ai-public-entrypoints.test.js scripts/__tests__/web3-mcp-server.test.js
- npm test
- npm run lint
- npm run ai:verify
- npx prettier --check README.md README.zh.md AGENTS.md docs/strategy/2026-05-14-execution-board.md docs/operations/2026-05-18-daily-report.md scripts/ai-content-core.mjs scripts/__tests__/generate-ai-index.test.js ai/content-index.json ai/manifest.json
- git diff --check
- cmp source/public AI artifacts
