### PR TITLE
docs: draft paid AI tools landing copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@
 - `docs/strategy/2026-05-14-sponsor-outreach-drafts.md`: 赞助外联话术草案；常规外联可自主执行，高风险赞助对象仍需单独确认。
 - `docs/strategy/2026-05-15-sponsor-leads-tracker.md`: 具名赞助/资助线索 tracker，记录公开来源、fit score、建议外联角度、渠道、状态和风险边界；发送外联后必须同步每日运营汇报。
 - `docs/strategy/2026-05-18-safe-reown-impact-memo.md`: 面向 Safe Ecosystem Foundation 和 Reown / WalletConnect 的资助/赞助 impact memo 草案，包含当前指标、官方来源、建议 ask、外联话术和发送前检查清单；尚未发送外联。
+- `docs/strategy/2026-05-18-paid-ai-tools-landing-copy.md`: 未来 hosted AI 工具 landing copy 草案，覆盖 `generate_personalized_web3_plan` 和 `audit_learning_answer` 的定位、CTA、边界文案、FAQ 和 launch checklist；不得描述为已上线付费能力。
 - `docs/strategy/2026-05-14-awesome-list-submissions.md`: awesome-list 和社区分发追踪，包含定位文案、目标列表、PR 模板和中文社区帖草案。
 - `docs/community/contributor-ladder.md`: 贡献者成长路径，定义 first-time contributor、repeat contributor、reviewer、module steward 和 community/sponsor ally。
 - `docs/community/good-first-issues.md`: 可复制到 GitHub Issues 的 starter issue 清单，包含标签、背景、验收标准和验证方式。

--- a/docs/operations/2026-05-18-daily-report.md
+++ b/docs/operations/2026-05-18-daily-report.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-05-18
 **Owner:** beihai + Codex
-**Reporting window:** 2026-05-18 10:25 CST snapshot; GitHub timestamps are UTC unless noted.
+**Reporting window:** 2026-05-18 10:47 CST snapshot; GitHub timestamps are UTC unless noted.
 
 ## KPI Snapshot
 
@@ -27,19 +27,21 @@
 - Community: seeded six new contributor-ready good-first issues [#157](https://github.com/beihaili/Get-Started-with-Web3/issues/157)-[#162](https://github.com/beihaili/Get-Started-with-Web3/issues/162), bringing the open good-first issue queue to 10.
 - Community infrastructure: updated issue templates to request expected files, definition of done, and good-first-issue suitability.
 - AI-native productization: added a copy-paste MCP client configuration snippet to both READMEs and generated AI artifacts, and corrected README glossary count to 55.
+- AI-native monetization: drafted landing-page copy for future hosted `generate_personalized_web3_plan` and `audit_learning_answer` tools, with explicit language that the local MCP remains free and read-only.
 - Operations hygiene: started the 2026-05-18 daily report with current metrics, release evidence, and next operating block.
 
 ## Deploy And Verification
 
 | Surface                  | Status  | Evidence                                                                                                                                                                                                        | Notes                                                               |
 | ------------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| Latest production deploy | Success | [Run 26009237958](https://github.com/beihaili/Get-Started-with-Web3/actions/runs/26009237958)                                                                                                                   | `docs: add bitcoin script examples` completed on main               |
+| Latest production deploy | Success | [Run 26010527068](https://github.com/beihaili/Get-Started-with-Web3/actions/runs/26010527068)                                                                                                                   | `docs: add mcp client setup snippet` completed on main              |
 | Release publication      | Success | [interactive-learning-2026-05-18](https://github.com/beihaili/Get-Started-with-Web3/releases/tag/interactive-learning-2026-05-18)                                                                               | Public GitHub product update published at 614 stars                 |
 | Production smoke         | Success | `/en/learn/module-11/11-2` and `/zh/.../11-2`                                                                                                                                                                   | Gas calculator rendered after latest Pages deploy; bad responses: 0 |
 | Sponsor memo             | Drafted | `docs/strategy/2026-05-18-safe-reown-impact-memo.md`                                                                                                                                                            | No outreach sent yet                                                |
 | Content verification     | Success | `npm test`, `npm run lint`, `npm run ai:verify`, `npm run build`                                                                                                                                                | Bitcoin Script examples and regenerated AI artifacts validated      |
 | Community backlog        | Success | [#156](https://github.com/beihaili/Get-Started-with-Web3/issues/156), [#157](https://github.com/beihaili/Get-Started-with-Web3/issues/157)-[#162](https://github.com/beihaili/Get-Started-with-Web3/issues/162) | Public roadmap pinned; 10 open good-first issues active             |
 | AI-native setup          | Success | `README.md`, `README.zh.md`, `ai/llms.txt`, `ai/manifest.json`                                                                                                                                                  | MCP client config snippet added; local AI verification passed       |
+| Paid AI tool copy        | Drafted | `docs/strategy/2026-05-18-paid-ai-tools-landing-copy.md`                                                                                                                                                        | Landing copy drafted; no payment enabled                            |
 | Formatting               | Success | `npx prettier --check`                                                                                                                                                                                          | Public post, tracker, and daily report Markdown use Prettier style  |
 | Whitespace               | Success | `git diff --check`                                                                                                                                                                                              | No whitespace errors                                                |
 
@@ -68,13 +70,14 @@
 - Translation coverage still reports 17 missing-English warnings; the visible contributor backlog remains useful but incomplete.
 - Sponsor outreach has not been sent; Safe/Reown memo is now ready, but actual sending still needs a human channel or connector.
 - Starter issue queue is healthy at 10 open good-first issues, but it now needs review responsiveness if external contributors arrive.
+- Paid AI tool copy is only a draft; enabling hosted payment, x402 enforcement, or any wallet/payment flow still requires explicit confirmation.
 
 ## Next Operating Block
 
 1. Publish the Draft 3 X/Farcaster thread and Chinese community post, then record links and visible metrics.
 2. Send the Safe or Reown memo through the chosen channel, then record the sent link/date and any reply.
 3. Draft the monthly contributor spotlight template and keep the pinned roadmap updated as issues close.
-4. Draft landing copy for `generate_personalized_web3_plan` and `audit_learning_answer`.
+4. Decide whether Phase 1 paid-tool validation should use waitlist/manual access, GitHub Sponsors, Stripe, or an x402 hosted experiment.
 
 ## Evidence Links
 
@@ -85,4 +88,5 @@
 - Merkle feature PR: https://github.com/beihaili/Get-Started-with-Web3/pull/148
 - Gas fee calculator PR: https://github.com/beihaili/Get-Started-with-Web3/pull/151
 - Public roadmap issue: https://github.com/beihaili/Get-Started-with-Web3/issues/156
-- Latest main deploy: https://github.com/beihaili/Get-Started-with-Web3/actions/runs/26009237958
+- Paid AI tools landing copy: `docs/strategy/2026-05-18-paid-ai-tools-landing-copy.md`
+- Latest main deploy: https://github.com/beihaili/Get-Started-with-Web3/actions/runs/26010527068

--- a/docs/strategy/2026-05-14-execution-board.md
+++ b/docs/strategy/2026-05-14-execution-board.md
@@ -72,7 +72,7 @@ Update weekly.
 
 - [x] Add a README quick demo showing how an agent can use `npm run mcp:web3`.
 - [x] Add one copy-paste MCP client setup snippet in README and AI artifacts.
-- [ ] Draft landing copy for `generate_personalized_web3_plan` and `audit_learning_answer`.
+- [x] Draft landing copy for `generate_personalized_web3_plan` and `audit_learning_answer`.
 - [ ] Decide whether Phase 1 paid tool should be x402, Stripe, GitHub Sponsors gated, or manual payment.
 - [ ] Keep local MCP free and clearly marked read-only.
 

--- a/docs/strategy/2026-05-14-sponsor-kit.md
+++ b/docs/strategy/2026-05-14-sponsor-kit.md
@@ -43,6 +43,7 @@ Notes:
 - Clone counts may include automated traffic and should not be treated as unique learners.
 - Public site analytics should be added to this kit once Cloudflare/GA data is reviewed.
 - Sponsor conversations should use the 2026-05-18 interactive learning release as the current proof point.
+- Future hosted AI tool copy is drafted in `docs/strategy/2026-05-18-paid-ai-tools-landing-copy.md`; it is not a live paid product and should be framed as a productization roadmap only.
 - Named sponsor leads and outreach status are tracked in `docs/strategy/2026-05-15-sponsor-leads-tracker.md`.
 
 ## Sponsorship Tiers
@@ -155,3 +156,4 @@ Start with products that match the curriculum and have low trust risk:
 3. Add current sponsor kit link to support page after the copy is checked against sponsor safety rules.
 4. Done: prepare first outreach batch of warm-fit targets in `docs/strategy/2026-05-15-sponsor-leads-tracker.md`.
 5. Use the lowest-friction available channel for first outreach and record the action in the daily report.
+6. Use the paid AI tools draft only as future-product context until beihai explicitly approves payment, wallet, or x402 activation.

--- a/docs/strategy/2026-05-18-paid-ai-tools-landing-copy.md
+++ b/docs/strategy/2026-05-18-paid-ai-tools-landing-copy.md
@@ -1,0 +1,181 @@
+# Paid AI Tools Landing Copy Draft
+
+**Date:** 2026-05-18
+**Status:** Internal positioning draft; not a live paid product
+**Owner:** beihai + Codex
+
+## Positioning
+
+Get Started with Web3 already exposes free, read-only AI-native learning surfaces: `llms.txt`, JSON artifacts, and a local MCP server. The next monetization experiment should keep that public-good layer free while testing lightweight hosted tools that save learners and educators time.
+
+The first paid-tool story:
+
+> Turn the open Web3 curriculum into cited, personalized learning help without asking beginners to trust generic Web3 advice.
+
+## Boundary Copy
+
+Use this copy anywhere these tools are mentioned before launch:
+
+> The local MCP server remains free and read-only. It does not sign transactions, execute chain operations, enforce payment, or handle x402 settlement. Paid-tool metadata in the manifest describes possible future hosted tools and should not be presented as a live checkout flow.
+
+Do not publish copy that implies:
+
+- A paid API is already live.
+- x402 settlement is already enforced.
+- The project gives investment advice.
+- A learner should connect a wallet or pay before the hosted tool is explicitly launched and reviewed.
+
+## Tool 1: Personalized Web3 Plan
+
+Manifest tool name: `generate_personalized_web3_plan`
+
+Future route: `/mcp/tools/generate_personalized_web3_plan`
+
+Current metadata price: `$0.25` on Base, not active.
+
+### One-Line Copy
+
+Generate a cited Web3 learning plan from your background, goals, risk tolerance, and weekly time budget.
+
+### Short Landing Copy
+
+Most Web3 learners do not need more random links. They need the right next lesson, a safe order of operations, and a way to avoid confusing wallet, chain, gas, bridge, and DeFi concepts too early. The personalized plan tool would turn the open Get Started with Web3 curriculum into a focused path with citations back to lessons, glossary entries, and public AI artifacts.
+
+### Expected Inputs
+
+- Current level: beginner, builder, researcher, or returning learner.
+- Goal: wallet safety, first DApp, smart contracts, DeFi basics, L2/cross-chain, DAO, Bitcoin, or smart accounts.
+- Language: Chinese or English.
+- Weekly time budget.
+- Constraints: avoid trading, focus on security, prepare for development, prepare for research, or review a specific topic.
+
+### Expected Output
+
+- A 7-day, 14-day, or 30-day plan.
+- Lesson sequence with cited links.
+- Key glossary terms to learn first.
+- Hands-on checkpoints.
+- Safety notes for wallet, signature, bridge, DeFi, or smart-account actions.
+- Optional next contributor issue if the learner wants to help the project.
+
+### CTA Drafts
+
+- Primary: `Generate my cited Web3 learning plan`
+- Secondary: `Browse the free curriculum first`
+- Agent CTA: `Use the free MCP server locally`
+
+## Tool 2: Learning Answer Audit
+
+Manifest tool name: `audit_learning_answer`
+
+Future route: `/mcp/tools/audit_learning_answer`
+
+Current metadata price: `$0.10` on Base, not active.
+
+### One-Line Copy
+
+Check a Web3 learning answer against the curriculum and get cited corrections without generic AI guesses.
+
+### Short Landing Copy
+
+Web3 beginners often write answers that sound plausible but miss a safety detail: approvals are not transfers, bridges add trust assumptions, smart accounts change key management, and DeFi yields carry protocol and market risk. The answer audit tool would review a learner's answer against the repository's lessons and glossary, then return concise corrections with citations.
+
+### Expected Inputs
+
+- Prompt or lesson question.
+- Learner answer.
+- Language preference.
+- Optional target module or topic.
+- Optional strictness: beginner-friendly, technical, or exam-style.
+
+### Expected Output
+
+- Correct / partially correct / needs review.
+- 3-5 cited corrections.
+- Missing safety warnings.
+- Misused terminology.
+- Suggested next lesson or glossary entry.
+- A short rewritten answer the learner can compare with their original.
+
+### CTA Drafts
+
+- Primary: `Audit my Web3 answer`
+- Secondary: `Read the cited lesson`
+- Educator CTA: `Use this for study group review`
+
+## Landing Page Structure
+
+### Hero
+
+Headline:
+
+> Cited Web3 learning help from an open curriculum
+
+Subcopy:
+
+> Generate personalized study paths and audit learning answers against Get Started with Web3. The free curriculum and local read-only MCP server stay open; hosted paid tools are a future experiment for learners who want faster guidance.
+
+Primary CTA:
+
+> Join the paid-tool waitlist
+
+Secondary CTA:
+
+> Use the free AI-native curriculum
+
+### Trust Strip
+
+- Open-source curriculum.
+- Bilingual content.
+- 106 indexed lesson entries.
+- 55 glossary entries.
+- Local MCP is free and read-only.
+- No investment advice or wallet signing.
+
+### Product Sections
+
+1. `Personalized Web3 Plan`
+   - For learners who know their goal but not the order.
+   - Shows a sample 14-day plan with lesson citations.
+2. `Learning Answer Audit`
+   - For learners, study groups, and educators.
+   - Shows a sample correction with links to lessons and glossary terms.
+3. `Free Agent Layer`
+   - Links to `llms.txt`, `ai/manifest.json`, `ai/content-index.json`, and MCP setup.
+   - Makes it explicit that local use is free.
+
+### FAQ
+
+**Are these tools live today?**
+
+Not yet. The manifest contains future-tool metadata so the project can design the product surface openly before activating hosted payment or access control.
+
+**Will the free curriculum stay free?**
+
+Yes. The core lessons, glossary, public AI artifacts, and local read-only MCP server should remain free.
+
+**Does this give investment advice?**
+
+No. The tools are for learning, citation, and safety review. They should not recommend tokens, trades, leverage, yield products, or timing.
+
+**Will users need to connect a wallet?**
+
+Not for the free local MCP. Any hosted paid-tool payment flow must be reviewed before launch and must not request seed phrases, private keys, or unsafe permissions.
+
+**Why paid tools at all?**
+
+Small paid utilities can fund maintenance, translation, and new lessons without putting ads or intrusive sponsor copy into the learning flow.
+
+## Launch Readiness Checklist
+
+- [ ] Decide payment path: x402, Stripe, GitHub Sponsors gated, or manual sponsor-supported access.
+- [ ] Confirm hosted runtime and abuse limits.
+- [ ] Add explicit privacy policy for submitted answers and learner goals.
+- [ ] Add no-investment-advice and no-wallet-signing warnings.
+- [ ] Add examples with real citations.
+- [ ] Add daily report tracking for waitlist, usage, revenue, support requests, and refunds.
+- [ ] Get explicit beihai confirmation before enabling any payment flow.
+
+## Recommendation
+
+Phase 1 should not enable payment immediately. The safer next step is to publish waitlist or interest-copy, collect 5-10 qualified user signals, and only then choose the payment mechanism. This keeps the project aligned with open education while preserving the option to test x402 or another hosted payment path later.


### PR DESCRIPTION
## Summary
- add an internal landing-copy draft for future hosted `generate_personalized_web3_plan` and `audit_learning_answer` tools
- update the execution board, sponsor kit, daily report, and AGENTS notes to record the productization boundary
- explicitly keep the local MCP server free/read-only and require beihai confirmation before any payment, wallet, or x402 activation

## Verification
- `npx prettier --check AGENTS.md docs/strategy/2026-05-18-paid-ai-tools-landing-copy.md docs/strategy/2026-05-14-execution-board.md docs/strategy/2026-05-14-sponsor-kit.md docs/operations/2026-05-18-daily-report.md`
- `git diff --check`