### PR TITLE
feat: add contributor spotlight loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 - `docs/strategy/2026-05-18-paid-ai-tools-landing-copy.md`: 未来 hosted AI 工具 landing copy 草案，覆盖 `generate_personalized_web3_plan` 和 `audit_learning_answer` 的定位、CTA、边界文案、FAQ 和 launch checklist；不得描述为已上线付费能力。
 - `docs/strategy/2026-05-14-awesome-list-submissions.md`: awesome-list 和社区分发追踪，包含定位文案、目标列表、PR 模板和中文社区帖草案。
 - `docs/community/contributor-ladder.md`: 贡献者成长路径，定义 first-time contributor、repeat contributor、reviewer、module steward 和 community/sponsor ally。
+- `docs/community/contributor-spotlight-template.md`: 月度贡献者 spotlight 模板，用于把公开 PR、issue、社区分发和增长指标转化为 GitHub/社交更新；不能承诺代币奖励、付费曝光或金融背书。
 - `docs/community/good-first-issues.md`: 可复制到 GitHub Issues 的 starter issue 清单，包含标签、背景、验收标准和验证方式。
 - `docs/operations/`: 每日运营汇报目录；`README.md` 定义 cadence、数据源和风险边界，`templates/daily-report-template.md` 是每日汇报模板，按 `YYYY-MM-DD-daily-report.md` 记录实际进展、指标、部署、外部分发、赞助线索和下一步。
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Start here:
 
 - [Contributing guide](CONTRIBUTING.en.md)
 - [Contributor ladder](docs/community/contributor-ladder.md)
+- [Contributor spotlight template](docs/community/contributor-spotlight-template.md)
 - [Good first issues catalog](docs/community/good-first-issues.md)
 - [Open good first issues](https://github.com/beihaili/Get-Started-with-Web3/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 - [All issues](https://github.com/beihaili/Get-Started-with-Web3/issues)

--- a/README.zh.md
+++ b/README.zh.md
@@ -173,6 +173,7 @@ npm run mcp:web3
 
 - [贡献指南](CONTRIBUTING.md)
 - [贡献者成长路径](docs/community/contributor-ladder.md)
+- [贡献者 Spotlight 模板](docs/community/contributor-spotlight-template.md)
 - [Good first issues 清单](docs/community/good-first-issues.md)
 - [good first issues](https://github.com/beihaili/Get-Started-with-Web3/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 - [所有 issues](https://github.com/beihaili/Get-Started-with-Web3/issues)

--- a/docs/community/contributor-ladder.md
+++ b/docs/community/contributor-ladder.md
@@ -50,6 +50,8 @@ Every monthly growth report should include:
 - Best community posts, submissions, or partner leads.
 - Star count, fork count, contributor count, and sponsor pipeline movement.
 
+Use `docs/community/contributor-spotlight-template.md` when turning this recognition loop into a public monthly update.
+
 ## Maintainer Checklist
 
 - Label starter work with `good first issue` only when the issue has clear acceptance criteria.

--- a/docs/community/contributor-spotlight-template.md
+++ b/docs/community/contributor-spotlight-template.md
@@ -1,0 +1,97 @@
+# Monthly Contributor Spotlight Template
+
+> 中文说明：这份模板用于每月公开感谢贡献者，并把贡献者成长路径、公开分发和 1000-star 目标连接起来。
+
+Use this template for a monthly GitHub Release note, roadmap issue update, README update, or social post. Keep it specific, cite visible work, and avoid promising sponsor placement, token rewards, financial upside, or preferential review.
+
+## Cadence
+
+- Draft once per month, ideally in the first week after the month closes.
+- Pull evidence from merged PRs, closed issues, public posts, releases, and the daily operations reports.
+- Mention contributors only when their work is public and relevant to the project.
+- Ask for consent before highlighting personal details beyond GitHub username, public profile, PRs, or public posts.
+
+## Selection Criteria
+
+Highlight up to five people or groups per month:
+
+- First-time contributors with a merged PR.
+- Repeat contributors who shipped multiple useful improvements.
+- Reviewers who gave practical feedback or reproduced issues.
+- Community allies who submitted the project to a list, wrote a useful post, or brought credible sponsor/grant leads.
+- Module stewards who kept one topic accurate, sourced, or beginner-friendly.
+
+## Data To Collect
+
+| Field             | Source                                                               |
+| ----------------- | -------------------------------------------------------------------- |
+| Month             | Reporting month                                                      |
+| GitHub username   | Merged PR, issue, or public profile                                  |
+| Contribution type | Content, translation, quiz, glossary, UI, AI-native, growth, review  |
+| Evidence link     | PR, issue, release, docs diff, or public post                        |
+| Impact            | What became clearer, safer, easier, faster, or more discoverable     |
+| Next invitation   | Suggested follow-up issue, reviewer role, or module stewardship path |
+
+## GitHub Update Draft
+
+```md
+## Contributor Spotlight: <Month YYYY>
+
+This month, Get Started with Web3 moved closer to becoming a sustainable open-source, bilingual, AI-native Web3 learning platform. Thank you to the contributors who improved the curriculum, tooling, review quality, and community reach.
+
+### Highlights
+
+- @<username> — <contribution type>: <one-sentence impact>. Evidence: <PR/issue/link>.
+- @<username> — <contribution type>: <one-sentence impact>. Evidence: <PR/issue/link>.
+- @<username> — <contribution type>: <one-sentence impact>. Evidence: <PR/issue/link>.
+
+### Project movement
+
+- Stars: <start> -> <end>
+- Forks: <start> -> <end>
+- Open good-first issues: <count>
+- Notable release or content update: <link>
+
+### Want to be featured next month?
+
+Pick a scoped starter task from the good-first issue queue, improve one lesson, add sources, proofread a translation, check an AI-native entrypoint, or help distribute a release. Small, well-reviewed PRs are the best way to start.
+```
+
+## X / Farcaster Draft
+
+```text
+Monthly Get Started with Web3 contributor spotlight:
+
+@<username> improved <impact>
+@<username> shipped <impact>
+@<username> helped with <impact>
+
+The project is growing toward 1000 GitHub stars as an open-source, bilingual, AI-native Web3 curriculum.
+
+Starter issues:
+<good-first-issues-url>
+```
+
+## 中文社区草稿
+
+```text
+Get Started with Web3 本月贡献者 spotlight：
+
+- @<username>：<贡献内容 + 影响>
+- @<username>：<贡献内容 + 影响>
+- @<username>：<贡献内容 + 影响>
+
+项目正在朝 1000 GitHub stars 和可持续开源 Web3 学习平台推进。欢迎从一个小任务开始：校对一节英文课程、补来源、改安全提示、加术语或检查 AI-native 入口。
+
+Good first issues:
+<good-first-issues-url>
+```
+
+## Maintainer Checklist
+
+- [ ] Verify every highlighted contribution has a public evidence link.
+- [ ] Avoid mentioning private conversations unless the contributor approved it.
+- [ ] Keep praise tied to concrete work and learner impact.
+- [ ] Link the contributor ladder and good-first issue queue.
+- [ ] Add the spotlight link to the daily operations report.
+- [ ] If posted externally, record the target, URL, and visible metrics.

--- a/docs/operations/2026-05-18-daily-report.md
+++ b/docs/operations/2026-05-18-daily-report.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-05-18
 **Owner:** beihai + Codex
-**Reporting window:** 2026-05-18 10:47 CST snapshot; GitHub timestamps are UTC unless noted.
+**Reporting window:** 2026-05-18 11:20 CST snapshot; GitHub timestamps are UTC unless noted.
 
 ## KPI Snapshot
 
@@ -28,18 +28,21 @@
 - Community infrastructure: updated issue templates to request expected files, definition of done, and good-first-issue suitability.
 - AI-native productization: added a copy-paste MCP client configuration snippet to both READMEs and generated AI artifacts, and corrected README glossary count to 55.
 - AI-native monetization: drafted landing-page copy for future hosted `generate_personalized_web3_plan` and `audit_learning_answer` tools, with explicit language that the local MCP remains free and read-only.
+- Community recognition: added a monthly contributor spotlight template and upgraded the contributors page with a starter-issue CTA, contributor ladder link, and conservative recognition boundary.
 - Operations hygiene: started the 2026-05-18 daily report with current metrics, release evidence, and next operating block.
 
 ## Deploy And Verification
 
 | Surface                  | Status  | Evidence                                                                                                                                                                                                        | Notes                                                               |
 | ------------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| Latest production deploy | Success | [Run 26010527068](https://github.com/beihaili/Get-Started-with-Web3/actions/runs/26010527068)                                                                                                                   | `docs: add mcp client setup snippet` completed on main              |
+| Latest production deploy | Success | [Run 26011146731](https://github.com/beihaili/Get-Started-with-Web3/actions/runs/26011146731)                                                                                                                   | `docs: draft paid AI tools landing copy` completed on main          |
 | Release publication      | Success | [interactive-learning-2026-05-18](https://github.com/beihaili/Get-Started-with-Web3/releases/tag/interactive-learning-2026-05-18)                                                                               | Public GitHub product update published at 614 stars                 |
 | Production smoke         | Success | `/en/learn/module-11/11-2` and `/zh/.../11-2`                                                                                                                                                                   | Gas calculator rendered after latest Pages deploy; bad responses: 0 |
 | Sponsor memo             | Drafted | `docs/strategy/2026-05-18-safe-reown-impact-memo.md`                                                                                                                                                            | No outreach sent yet                                                |
 | Content verification     | Success | `npm test`, `npm run lint`, `npm run ai:verify`, `npm run build`                                                                                                                                                | Bitcoin Script examples and regenerated AI artifacts validated      |
 | Community backlog        | Success | [#156](https://github.com/beihaili/Get-Started-with-Web3/issues/156), [#157](https://github.com/beihaili/Get-Started-with-Web3/issues/157)-[#162](https://github.com/beihaili/Get-Started-with-Web3/issues/162) | Public roadmap pinned; 10 open good-first issues active             |
+| Contributor spotlight    | Drafted | `docs/community/contributor-spotlight-template.md`, `/contributors`                                                                                                                                             | Monthly recognition loop prepared; no rewards promised              |
+| Contributor page smoke   | Success | `npm test`, `npm run lint`, `npm run build`, Playwright desktop/mobile smoke                                                                                                                                    | CTA links and recognition boundary visible on `/en/contributors`    |
 | AI-native setup          | Success | `README.md`, `README.zh.md`, `ai/llms.txt`, `ai/manifest.json`                                                                                                                                                  | MCP client config snippet added; local AI verification passed       |
 | Paid AI tool copy        | Drafted | `docs/strategy/2026-05-18-paid-ai-tools-landing-copy.md`                                                                                                                                                        | Landing copy drafted; no payment enabled                            |
 | Formatting               | Success | `npx prettier --check`                                                                                                                                                                                          | Public post, tracker, and daily report Markdown use Prettier style  |
@@ -69,14 +72,14 @@
 - GitHub Discussions are disabled, so GitHub-native community updates currently need to use Releases, Issues, PR comments, or README/docs.
 - Translation coverage still reports 17 missing-English warnings; the visible contributor backlog remains useful but incomplete.
 - Sponsor outreach has not been sent; Safe/Reown memo is now ready, but actual sending still needs a human channel or connector.
-- Starter issue queue is healthy at 10 open good-first issues, but it now needs review responsiveness if external contributors arrive.
+- Starter issue queue is healthy at 10 open good-first issues; contributor recognition now has a template, but it needs real PR activity before the first spotlight can be published.
 - Paid AI tool copy is only a draft; enabling hosted payment, x402 enforcement, or any wallet/payment flow still requires explicit confirmation.
 
 ## Next Operating Block
 
 1. Publish the Draft 3 X/Farcaster thread and Chinese community post, then record links and visible metrics.
 2. Send the Safe or Reown memo through the chosen channel, then record the sent link/date and any reply.
-3. Draft the monthly contributor spotlight template and keep the pinned roadmap updated as issues close.
+3. Keep the pinned roadmap updated as issues close, and use the contributor spotlight template after the next public contribution cycle.
 4. Decide whether Phase 1 paid-tool validation should use waitlist/manual access, GitHub Sponsors, Stripe, or an x402 hosted experiment.
 
 ## Evidence Links
@@ -88,5 +91,6 @@
 - Merkle feature PR: https://github.com/beihaili/Get-Started-with-Web3/pull/148
 - Gas fee calculator PR: https://github.com/beihaili/Get-Started-with-Web3/pull/151
 - Public roadmap issue: https://github.com/beihaili/Get-Started-with-Web3/issues/156
+- Contributor spotlight template: `docs/community/contributor-spotlight-template.md`
 - Paid AI tools landing copy: `docs/strategy/2026-05-18-paid-ai-tools-landing-copy.md`
-- Latest main deploy: https://github.com/beihaili/Get-Started-with-Web3/actions/runs/26010527068
+- Latest main deploy: https://github.com/beihaili/Get-Started-with-Web3/actions/runs/26011146731

--- a/docs/strategy/2026-05-14-execution-board.md
+++ b/docs/strategy/2026-05-14-execution-board.md
@@ -95,8 +95,8 @@ Update weekly.
 - [x] Improve issue templates with "expected files", "definition of done", and "good first issue candidate".
 - [x] Keep 10-20 good first issues active; 10 open as of 2026-05-18.
 - [x] Add contributor ladder to CONTRIBUTING docs.
-- [ ] Draft monthly contributor spotlight template.
-- [ ] Ensure contributor page has a reason to share.
+- [x] Draft monthly contributor spotlight template.
+- [x] Ensure contributor page has a reason to share.
 
 ### 7. Technical Stewardship
 

--- a/src/i18n/locales/en/contributors.json
+++ b/src/i18n/locales/en/contributors.json
@@ -1,7 +1,13 @@
 {
   "pageTitle": "Contributors",
-  "pageDesc": "Meet the people who built this platform",
+  "pageDesc": "Meet the people building this open Web3 learning platform",
   "heading": "Our Contributors",
+  "spotlightEyebrow": "Monthly contributor spotlight",
+  "spotlightHeading": "Your first useful PR can become a public project update",
+  "spotlightDesc": "Merged contributions are eligible for the monthly spotlight, roadmap updates, and community posts when they make the curriculum clearer, safer, more complete, or easier to share.",
+  "spotlightPrimaryCta": "Pick a starter issue",
+  "spotlightSecondaryCta": "Read the ladder",
+  "spotlightShareNote": "Recognition is tied to public work and learner impact. The project does not promise token rewards, paid placement, or financial endorsements for contributions.",
   "contributions": "contributions",
   "loading": "Loading contributors...",
   "error": "Failed to load contributors"

--- a/src/i18n/locales/zh/contributors.json
+++ b/src/i18n/locales/zh/contributors.json
@@ -1,7 +1,13 @@
 {
   "pageTitle": "Contributors",
-  "pageDesc": "认识共同建设这个平台的人们",
+  "pageDesc": "认识一起建设这个开源 Web3 学习平台的人们",
   "heading": "项目贡献者",
+  "spotlightEyebrow": "月度贡献者 Spotlight",
+  "spotlightHeading": "你的第一个有效 PR 可以成为公开项目进展",
+  "spotlightDesc": "当贡献让课程更清晰、更安全、更完整或更容易传播时，合并后的贡献有机会进入月度 spotlight、roadmap 更新和社区帖子。",
+  "spotlightPrimaryCta": "选择入门任务",
+  "spotlightSecondaryCta": "查看成长路径",
+  "spotlightShareNote": "贡献者认可只基于公开工作和学习者价值；项目不会承诺代币奖励、付费曝光或金融背书。",
   "contributions": "次贡献",
   "loading": "加载贡献者中...",
   "error": "贡献者列表加载失败"

--- a/src/pages/ContributorsPage.jsx
+++ b/src/pages/ContributorsPage.jsx
@@ -1,12 +1,16 @@
 import { useState, useEffect } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { ArrowLeft, Users } from 'lucide-react';
+import { ArrowLeft, ExternalLink, GitPullRequest, Share2, Users } from 'lucide-react';
 import SeoHead from '../components/SeoHead';
 import LanguageSwitcher from '../components/LanguageSwitcher';
 
 const CACHE_KEY = 'gh_contributors_cache';
 const API_URL = 'https://api.github.com/repos/beihaili/Get-Started-with-Web3/contributors';
+const GOOD_FIRST_ISSUES_URL =
+  'https://github.com/beihaili/Get-Started-with-Web3/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22';
+const CONTRIBUTOR_LADDER_URL =
+  'https://github.com/beihaili/Get-Started-with-Web3/blob/main/docs/community/contributor-ladder.md';
 
 /**
  * Fetches contributors from GitHub API with sessionStorage caching
@@ -104,6 +108,46 @@ const ContributorsPage = () => {
             {t('contributors.pageDesc')}
           </p>
         </div>
+
+        <section className="mb-12 rounded-lg border border-cyan-200/70 bg-cyan-50/70 p-6 dark:border-cyan-500/20 dark:bg-cyan-950/30">
+          <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+            <div className="max-w-2xl">
+              <div className="mb-3 inline-flex items-center gap-2 text-sm font-semibold text-cyan-700 dark:text-cyan-300">
+                <Share2 className="h-4 w-4" />
+                {t('contributors.spotlightEyebrow')}
+              </div>
+              <h2 className="text-2xl font-bold text-slate-900 dark:text-white">
+                {t('contributors.spotlightHeading')}
+              </h2>
+              <p className="mt-3 text-sm leading-6 text-slate-600 dark:text-slate-300">
+                {t('contributors.spotlightDesc')}
+              </p>
+            </div>
+            <div className="flex shrink-0 flex-col gap-3 sm:flex-row md:flex-col">
+              <a
+                href={GOOD_FIRST_ISSUES_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-slate-700 dark:bg-white dark:text-slate-950 dark:hover:bg-cyan-100"
+              >
+                <GitPullRequest className="h-4 w-4" />
+                {t('contributors.spotlightPrimaryCta')}
+              </a>
+              <a
+                href={CONTRIBUTOR_LADDER_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:border-cyan-500 hover:text-cyan-700 dark:border-slate-700 dark:text-slate-200 dark:hover:border-cyan-400 dark:hover:text-cyan-300"
+              >
+                <ExternalLink className="h-4 w-4" />
+                {t('contributors.spotlightSecondaryCta')}
+              </a>
+            </div>
+          </div>
+          <p className="mt-5 border-t border-cyan-200/70 pt-4 text-xs leading-5 text-slate-500 dark:border-cyan-500/20 dark:text-slate-400">
+            {t('contributors.spotlightShareNote')}
+          </p>
+        </section>
 
         {/* Loading state */}
         {loading && (

--- a/src/pages/__tests__/ContributorsPage.test.jsx
+++ b/src/pages/__tests__/ContributorsPage.test.jsx
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import ContributorsPage from '../ContributorsPage';
+import LanguageProvider from '../../i18n/LanguageProvider';
+import i18n from '../../i18n';
+import { loadI18nSections } from '../../i18n/namespaceLoaders';
+
+async function prepareContributorsTranslations() {
+  await i18n.changeLanguage('en');
+  await loadI18nSections(i18n, ['contributors', 'support'], 'en');
+}
+
+function renderContributorsPage(initialEntry = '/en/contributors') {
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route
+          path="/:lang/contributors"
+          element={
+            <LanguageProvider>
+              <ContributorsPage />
+            </LanguageProvider>
+          }
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('ContributorsPage', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  beforeEach(async () => {
+    sessionStorage.clear();
+    await prepareContributorsTranslations();
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => [
+          {
+            id: 1,
+            login: 'alice',
+            avatar_url: 'https://example.com/alice.png',
+            html_url: 'https://github.com/alice',
+            contributions: 3,
+          },
+        ],
+      }))
+    );
+  });
+
+  it('shows the contributor spotlight CTA and contributor grid', async () => {
+    renderContributorsPage();
+
+    expect(screen.getByText('Monthly contributor spotlight')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Pick a starter issue' })).toHaveAttribute(
+      'href',
+      expect.stringContaining('label%3A%22good%20first%20issue%22')
+    );
+    expect(screen.getByRole('link', { name: 'Read the ladder' })).toHaveAttribute(
+      'href',
+      expect.stringContaining('docs/community/contributor-ladder.md')
+    );
+
+    expect(await screen.findByText('alice')).toBeInTheDocument();
+    expect(screen.getByText('3 contributions')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a monthly contributor spotlight template for public recognition, roadmap updates, and social/community posts
- update `/contributors` with a starter-issue CTA, contributor ladder link, and conservative recognition boundary
- link the spotlight template from README files, contributor ladder, AGENTS, execution board, and the daily report
- add a ContributorsPage test covering the new CTA and contributor grid

## Verification
- `npx prettier --check src/pages/ContributorsPage.jsx src/pages/__tests__/ContributorsPage.test.jsx docs/community/contributor-spotlight-template.md docs/operations/2026-05-18-daily-report.md AGENTS.md README.md README.zh.md docs/community/contributor-ladder.md docs/strategy/2026-05-14-execution-board.md src/i18n/locales/en/contributors.json src/i18n/locales/zh/contributors.json`
- `npx vitest run src/pages/__tests__/ContributorsPage.test.jsx src/i18n/__tests__/i18n.test.js`
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run ai:verify`
- Playwright desktop/mobile smoke for `/en/contributors` with analytics blocked and GitHub contributors API mocked