### PR TITLE
docs: record dependabot triage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,31 +1,40 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: 'weekly'
+      day: 'monday'
     open-pull-requests-limit: 5
     labels:
-      - "dependencies"
+      - 'dependencies'
     # Only group minor/patch updates. Major updates get their own PR
     # so breaking changes (e.g. tailwind v3→v4, react-router v6→v7) can be
     # reviewed and migrated individually.
     groups:
       dev-dependencies-minor:
-        dependency-type: "development"
+        dependency-type: 'development'
         update-types:
-          - "minor"
-          - "patch"
+          - 'minor'
+          - 'patch'
       production-dependencies-minor:
-        dependency-type: "production"
+        dependency-type: 'production'
         update-types:
-          - "minor"
-          - "patch"
-  - package-ecosystem: "github-actions"
-    directory: "/"
+          - 'minor'
+          - 'patch'
+    # Keep Node 22-only dev-tool majors out of the weekly queue until the
+    # project intentionally migrates CI and local contributor docs from Node 20.
+    ignore:
+      - dependency-name: '@commitlint/cli'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'lint-staged'
+        update-types:
+          - 'version-update:semver-major'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "monthly"
+      interval: 'monthly'
     labels:
-      - "dependencies"
-      - "github-actions"
+      - 'dependencies'
+      - 'github-actions'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@
 - `.github/ISSUE_TEMPLATE/`: Bug、feature、content/translation、growth/community 分流模板。
 - `.github/PULL_REQUEST_TEMPLATE.md`: PR 验证和内容安全检查清单。
 - `.github/workflows/deploy.yml`: PR 构建会上传 `dist` artifact，并用固定 marker 更新同一条 PR 评论，方便评审者从 Actions run 下载构建产物；合并到 `main` 后才部署 GitHub Pages。
+- `.github/dependabot.yml`: 每周检查 npm 依赖和每月检查 GitHub Actions；minor/patch 更新分组，major 更新单独处理；`@commitlint/cli` v21 和 `lint-staged` v17 当前被忽略，因为它们要求 Node 22，而项目 CI 仍使用 Node 20，需等计划内 Node 22 迁移后再解除。
 - GitHub Issue [#156](https://github.com/beihaili/Get-Started-with-Web3/issues/156): 已 pin 的公开 1000-star roadmap；维护 starter issue 队列、翻译、分发、AI-native 和赞助动作时同步参考。
 
 工作边界：
@@ -148,4 +149,5 @@ Agent 使用 MCP 工具回答时，应优先引用工具返回的 `citation.file
 - 英文课程 README 可以复用对应中文课程目录下的本地图片；`npm run sync-content` 会按 README 中的本地图片引用补齐缺失英文发布资产。若英文课程需要不同图片，直接放到 `en/` 对应目录，脚本不会覆盖已有英文图片。
 - 新增术语时，更新 `src/config/glossaryData.js` 和对应测试，保持 `GLOSSARY_CATEGORIES` 与测试允许分类一致，再运行 `npm run ai:index`。
 - MCP 工具必须保持只读，返回结果需包含可引用的 `citation.file` 或 URL。
+- 接受 Dependabot major 更新前，先检查包的 `engines.node` 与 `.github/workflows/*.yml` 中的 Node 版本；Node 22-only 工具链更新必须作为独立迁移处理。
 - 修改代码后至少运行相关 Vitest；完成前运行 `npm test` 和 `npm run lint`。

--- a/docs/operations/2026-05-19-daily-report.md
+++ b/docs/operations/2026-05-19-daily-report.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-05-19
 **Owner:** beihai + Codex
-**Reporting window:** 2026-05-19 08:45 CST snapshot; GitHub timestamps are UTC unless noted.
+**Reporting window:** 2026-05-19 10:03 CST snapshot; GitHub timestamps are UTC unless noted.
 
 ## KPI Snapshot
 
@@ -12,7 +12,7 @@
 | Forks             |      58 |                  57 |       +1 | `gh repo view beihaili/Get-Started-with-Web3` |
 | Watchers          |       3 |                   3 |        0 | `gh repo view beihaili/Get-Started-with-Web3` |
 | Contributors      |      13 |                  13 |        0 | `gh api repos/.../contributors`               |
-| Open PRs          |       3 |                   0 |       +3 | `gh pr list --state open`                     |
+| Open PRs          |       0 |                   0 |        0 | `gh pr list --state open`                     |
 | Open issues       |      12 |                  12 |        0 | `gh issue list --state open --limit 200`      |
 | Good first issues |      11 |                  11 |        0 | `gh issue list` label count                   |
 
@@ -24,32 +24,33 @@
 - Community backlog: updated [#175](https://github.com/beihaili/Get-Started-with-Web3/issues/175#issuecomment-4483580706) so contributors can see that lesson 9-2 is complete and only lessons 9-3 to 9-5 remain in that issue.
 - Contributor loop: [#177](https://github.com/beihaili/Get-Started-with-Web3/pull/177) and [#178](https://github.com/beihaili/Get-Started-with-Web3/pull/178) merged, closing [#162](https://github.com/beihaili/Get-Started-with-Web3/issues/162) and [#158](https://github.com/beihaili/Get-Started-with-Web3/issues/158).
 - Community backlog: opened replacement growth starter issues [#186](https://github.com/beihaili/Get-Started-with-Web3/issues/186) and [#187](https://github.com/beihaili/Get-Started-with-Web3/issues/187), keeping the open good-first issue queue at 11.
-- GitHub triage: Dependabot PRs [#179](https://github.com/beihaili/Get-Started-with-Web3/pull/179) and [#180](https://github.com/beihaili/Get-Started-with-Web3/pull/180) landed; three Dependabot PRs remain open.
+- GitHub triage: Dependabot PRs [#179](https://github.com/beihaili/Get-Started-with-Web3/pull/179), [#180](https://github.com/beihaili/Get-Started-with-Web3/pull/180), and [#182](https://github.com/beihaili/Get-Started-with-Web3/pull/182) landed; [#181](https://github.com/beihaili/Get-Started-with-Web3/pull/181) and [#183](https://github.com/beihaili/Get-Started-with-Web3/pull/183) were closed with Node 22 migration notes, leaving the open PR queue at 0.
+- Dependency hygiene: `.github/dependabot.yml` now ignores Node 22-only major updates for `@commitlint/cli` and `lint-staged` until the project intentionally migrates CI and local contributor docs from Node 20.
 
 ## Deploy And Verification
 
-| Surface                  | Status  | Evidence                                                                                      | Notes                                                                                                     |
-| ------------------------ | ------- | --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| Latest production deploy | Success | [Run 26069716949](https://github.com/beihaili/Get-Started-with-Web3/actions/runs/26069716949) | Main deploy for [#184](https://github.com/beihaili/Get-Started-with-Web3/pull/184) completed successfully |
-| Public lesson route      | Success | `curl -L .../en/learn/module-9/9-2`                                                           | HTTP 200 and prerendered HTML contains `Rollup Principles Explained`                                      |
-| Translation coverage     | Success | `npm run translation:check`                                                                   | 15 missing-English warnings remain after adding lesson 9-2                                                |
-| AI index                 | Success | `npm run ai:index`, `npm run ai:publish`                                                      | 11 modules, 108 lesson entries, 57 glossary entries                                                       |
-| AI entrypoints           | Success | `npm run ai:verify`                                                                           | Source/public artifacts, MCP tools, `llms.txt`, and x402 metadata pass                                    |
-| Test suite               | Success | `npm test`                                                                                    | 40 test files and 217 tests passed                                                                        |
-| Lint                     | Success | `npm run lint`                                                                                | ESLint completed with zero reported errors                                                                |
-| Production build         | Success | `npm run build`                                                                               | Vite build plus 131/131 prerendered routes passed, including `/en/learn/module-9/9-2`                     |
-| Formatting               | Success | `npx prettier --check ...`                                                                    | Changed Markdown files use Prettier style                                                                 |
-| Whitespace               | Success | `git diff --check`                                                                            | No whitespace errors                                                                                      |
+| Surface                  | Status  | Evidence                                                                                      | Notes                                                                                                                            |
+| ------------------------ | ------- | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Latest production deploy | Success | [Run 26071427382](https://github.com/beihaili/Get-Started-with-Web3/actions/runs/26071427382) | Main deploy for [#182](https://github.com/beihaili/Get-Started-with-Web3/pull/182) completed successfully; latest head `7000aa4` |
+| Public lesson route      | Success | `curl -L .../en/learn/module-9/9-2`                                                           | HTTP 200 and prerendered HTML contains `Rollup Principles Explained`                                                             |
+| Translation coverage     | Success | `npm run translation:check`                                                                   | 15 missing-English warnings remain after adding lesson 9-2                                                                       |
+| AI index                 | Success | `npm run ai:index`, `npm run ai:publish`                                                      | 11 modules, 108 lesson entries, 57 glossary entries                                                                              |
+| AI entrypoints           | Success | `npm run ai:verify`                                                                           | Source/public artifacts, MCP tools, `llms.txt`, and x402 metadata pass                                                           |
+| Test suite               | Success | `npm test`                                                                                    | 40 test files and 217 tests passed                                                                                               |
+| Lint                     | Success | `npm run lint`                                                                                | ESLint completed with zero reported errors                                                                                       |
+| Production build         | Success | `npm run build`                                                                               | Vite build plus 131/131 prerendered routes passed, including `/en/learn/module-9/9-2`                                            |
+| Formatting               | Success | `npx prettier --check ...`                                                                    | Changed Markdown files use Prettier style                                                                                        |
+| Whitespace               | Success | `git diff --check`                                                                            | No whitespace errors                                                                                                             |
 
 ## External Distribution
 
-| Target                       | Status       | Evidence                                                                                            | Next action                                             |
-| ---------------------------- | ------------ | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| GitHub contributor backlog   | Updated      | [#175 update](https://github.com/beihaili/Get-Started-with-Web3/issues/175#issuecomment-4483580706) | Remaining L2 translation work is now lessons 9-3 to 9-5 |
-| GitHub PR queue              | Needs triage | `gh pr list --state open`                                                                           | Review remaining Dependabot PRs #181-#183               |
-| Twitter/X and Farcaster post | Ready        | `docs/strategy/2026-05-15-public-post-drafts.md`                                                    | Publish Draft 3 from beihai account                     |
-| learnblockchain.cn/community | Ready        | `docs/strategy/2026-05-15-public-post-drafts.md`                                                    | Publish Chinese community post when convenient          |
-| TensorBlock awesome MCP      | Waiting      | [PR #544](https://github.com/TensorBlock/awesome-mcp-servers/pull/544)                              | Avoid repeat pings until reviewer responds              |
+| Target                       | Status  | Evidence                                                                                            | Next action                                                           |
+| ---------------------------- | ------- | --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| GitHub contributor backlog   | Updated | [#175 update](https://github.com/beihaili/Get-Started-with-Web3/issues/175#issuecomment-4483580706) | Remaining L2 translation work is now lessons 9-3 to 9-5               |
+| GitHub PR queue              | Clear   | `gh pr list --state open`                                                                           | Revisit Node 22-only dev-tool majors during planned Node 22 migration |
+| Twitter/X and Farcaster post | Ready   | `docs/strategy/2026-05-15-public-post-drafts.md`                                                    | Publish Draft 3 from beihai account                                   |
+| learnblockchain.cn/community | Ready   | `docs/strategy/2026-05-15-public-post-drafts.md`                                                    | Publish Chinese community post when convenient                        |
+| TensorBlock awesome MCP      | Waiting | [PR #544](https://github.com/TensorBlock/awesome-mcp-servers/pull/544)                              | Avoid repeat pings until reviewer responds                            |
 
 ## Sponsor And Revenue
 
@@ -63,7 +64,7 @@
 ## Blockers And Risks
 
 - Growth remains flat at 614 stars; the next growth move needs actual public distribution, not only internal content shipping.
-- Open PRs are down to 3 after #177, #178, #179, and #180 landed; the remaining Dependabot PRs still need controlled review.
+- Dependabot queue is clear, but Node 22 migration remains a technical stewardship item before accepting `@commitlint/cli` v21 or `lint-staged` v17.
 - Layer 2 English coverage improves, but three lessons still remain after this branch; broader DAO and non-core docs still need translation or classification.
 - Sponsor outreach remains drafted but unsent; actual external sending still needs a confirmed human channel or connector.
 - Hosted payment, x402 enforcement, affiliate expansion, wallet flows, and payment-address changes still require explicit user confirmation.
@@ -71,14 +72,14 @@
 ## Next Operating Block
 
 1. Continue the remaining Layer 2 English translations with `L2CrossChain/03_L2Ecosystem`, or leave it open for contributors if #175 gets picked up.
-2. Triage remaining Dependabot PRs [#181](https://github.com/beihaili/Get-Started-with-Web3/pull/181)-[#183](https://github.com/beihaili/Get-Started-with-Web3/pull/183) with full CI evidence before merging.
+2. Plan the Node 22 migration separately before accepting `@commitlint/cli` v21 or `lint-staged` v17.
 3. Publish the ready X/Farcaster and Chinese community posts so the new content work feeds the 1000-star growth loop.
 
 ## Evidence Links
 
 - Repository: https://github.com/beihaili/Get-Started-with-Web3
 - Production site: https://beihaili.github.io/Get-Started-with-Web3/
-- Latest main deploy: https://github.com/beihaili/Get-Started-with-Web3/actions/runs/26069716949
+- Latest main deploy: https://github.com/beihaili/Get-Started-with-Web3/actions/runs/26071427382
 - Remaining L2 translation starter issue: https://github.com/beihaili/Get-Started-with-Web3/issues/175
 - Remaining L2 translation issue update: https://github.com/beihaili/Get-Started-with-Web3/issues/175#issuecomment-4483580706
 - First L2 English translation PR: https://github.com/beihaili/Get-Started-with-Web3/pull/174
@@ -86,6 +87,9 @@
 - Second L2 English translation: `en/L2CrossChain/02_RollupPrinciples/README.md`
 - Quiz contributor PR: https://github.com/beihaili/Get-Started-with-Web3/pull/177
 - Glossary contributor PR: https://github.com/beihaili/Get-Started-with-Web3/pull/178
+- Dependabot eslint-config-prettier PR: https://github.com/beihaili/Get-Started-with-Web3/pull/182
+- Closed Node 22-only commitlint PR: https://github.com/beihaili/Get-Started-with-Web3/pull/181
+- Closed Node 22-only lint-staged PR: https://github.com/beihaili/Get-Started-with-Web3/pull/183
 - Replacement starter issue: https://github.com/beihaili/Get-Started-with-Web3/issues/186
 - Replacement starter issue: https://github.com/beihaili/Get-Started-with-Web3/issues/187
 - AI manifest: `ai/manifest.json`

--- a/docs/strategy/2026-05-14-execution-board.md
+++ b/docs/strategy/2026-05-14-execution-board.md
@@ -6,16 +6,16 @@
 
 ## Current Snapshot
 
-| Area             | Status                 | Next Action                                                                      |
-| ---------------- | ---------------------- | -------------------------------------------------------------------------------- |
-| Technical health | Healthy, with PR queue | Keep `npm test`, `npm run lint`, `npm run ai:verify` green and triage 3 open PRs |
-| GitHub growth    | Under-monetized        | Improve README conversion and launch distribution campaigns                      |
-| SEO              | Partially implemented  | Fix language metadata and route coverage                                         |
-| English content  | Incomplete             | Close 15 missing translations or classify non-course docs                        |
-| AI-native layer  | Strong MVP             | Productize story and prepare paid-tool landing                                   |
-| Monetization     | Passive only           | Create sponsor kit and sponsor outreach drafts                                   |
-| Community        | Converting             | Keep accepted contributor PRs moving into recognition and backlog refresh        |
-| Personal brand   | Underused              | Convert every shipment into public posts and distribution assets                 |
+| Area             | Status                | Next Action                                                                                      |
+| ---------------- | --------------------- | ------------------------------------------------------------------------------------------------ |
+| Technical health | Healthy               | Keep `npm test`, `npm run lint`, `npm run ai:verify` green and plan Node 22 migration separately |
+| GitHub growth    | Under-monetized       | Improve README conversion and launch distribution campaigns                                      |
+| SEO              | Partially implemented | Fix language metadata and route coverage                                                         |
+| English content  | Incomplete            | Close 15 missing translations or classify non-course docs                                        |
+| AI-native layer  | Strong MVP            | Productize story and prepare paid-tool landing                                                   |
+| Monetization     | Passive only          | Create sponsor kit and sponsor outreach drafts                                                   |
+| Community        | Converting            | Keep accepted contributor PRs moving into recognition and backlog refresh                        |
+| Personal brand   | Underused             | Convert every shipment into public posts and distribution assets                                 |
 
 ## KPI Board
 
@@ -110,7 +110,8 @@ Update weekly.
 - [x] Correct Tailwind CSS v4 entrypoint so production builds emit full theme utilities and class-based dark mode styles.
 - [x] Add `sync-content` fallback coverage so English lessons do not ship broken local image references when the corresponding Chinese assets exist.
 - [x] Prepare PR build artifact comments for [#40](https://github.com/beihaili/Get-Started-with-Web3/issues/40) so contributors can download reviewed builds from the Actions run.
-- [ ] Keep Dependabot and contributor PRs under control; 3 open Dependabot PRs need triage as of 2026-05-19.
+- [x] Clear the 2026-05-19 Dependabot queue; merge Node-20-compatible updates and close Node-22-only majors with notes.
+- [ ] Plan Node 22 migration before accepting `@commitlint/cli` v21 or `lint-staged` v17.
 - [ ] Run `npm test`, `npm run lint`, and `npm run ai:verify` before claiming work is complete.
 - [x] Expose translation coverage checks through `npm run translation:check`.
 - [ ] Run `npm run build` before shipping SEO/prerender changes.
@@ -176,3 +177,4 @@ Daily report should include:
 | 2026-05-18 | Published first Layer 2 English translation and backfilled translation backlog                  | Merged [#174](https://github.com/beihaili/Get-Started-with-Web3/pull/174) for `en/L2CrossChain/01_WhyScaling/README.md`, reduced missing English translation warnings from 17 to 16, and opened follow-up starter issue [#175](https://github.com/beihaili/Get-Started-with-Web3/issues/175) for the remaining module 9 lessons                                                                                                                                                                                                      |
 | 2026-05-19 | Published second Layer 2 English translation                                                    | Merged [#184](https://github.com/beihaili/Get-Started-with-Web3/pull/184) for `en/L2CrossChain/02_RollupPrinciples/README.md`, regenerated AI artifacts to 108 lesson entries, reduced local translation coverage warnings from 16 to 15, confirmed main deploy [run 26069716949](https://github.com/beihaili/Get-Started-with-Web3/actions/runs/26069716949), and updated [#175](https://github.com/beihaili/Get-Started-with-Web3/issues/175#issuecomment-4483580706)                                                              |
 | 2026-05-19 | Replenished starter backlog and synced glossary artifacts                                       | [#177](https://github.com/beihaili/Get-Started-with-Web3/pull/177) and [#178](https://github.com/beihaili/Get-Started-with-Web3/pull/178) landed, closing [#162](https://github.com/beihaili/Get-Started-with-Web3/issues/162) and [#158](https://github.com/beihaili/Get-Started-with-Web3/issues/158); opened growth starter issues [#186](https://github.com/beihaili/Get-Started-with-Web3/issues/186) and [#187](https://github.com/beihaili/Get-Started-with-Web3/issues/187); regenerated AI artifacts to 57 glossary entries |
+| 2026-05-19 | Cleared Dependabot queue                                                                        | Merged Node-20-compatible [#182](https://github.com/beihaili/Get-Started-with-Web3/pull/182) after local `npm run lint` and `npm test`; closed Node-22-only [#181](https://github.com/beihaili/Get-Started-with-Web3/pull/181) and [#183](https://github.com/beihaili/Get-Started-with-Web3/pull/183); added Dependabot ignore rules for those major lines until a planned Node 22 migration                                                                                                                                         |


### PR DESCRIPTION
## Summary
- record the completed Dependabot triage in the daily operations report and execution board
- add Dependabot ignore rules for Node 22-only major lines: @commitlint/cli v21 and lint-staged v17
- update AGENTS.md with the dependency-major review rule and Node 22 migration boundary

## Validation
- npx prettier --check .github/dependabot.yml docs/operations/2026-05-19-daily-report.md docs/strategy/2026-05-14-execution-board.md AGENTS.md
- ruby -e "require 'yaml'; YAML.load_file('.github/dependabot.yml'); puts 'dependabot.yml ok'"\n- git diff --check\n- npm run ai:verify\n- npm run lint\n- npm test\n\n## Notes\n- #182 was merged after local lint/test verification.\n- #181 and #183 were closed because their latest majors require Node 22 while the repo still runs Node 20 in CI.