### PR TITLE
docs(growth): add weekly public content calendar

### DIFF
--- a/docs/operations/2026-05-19-daily-report.md
+++ b/docs/operations/2026-05-19-daily-report.md
@@ -22,6 +22,7 @@
 - AI-native maintenance: regenerated `ai/` and `public/ai/` artifacts after the new English lesson and smart-account glossary merge; the AI-native index now contains 108 lesson entries, 57 glossary entries, and module `9-2` has English availability set to `true`.
 - Translation operations: reduced local translation coverage warnings from 16 to 15; the remaining Layer 2 gaps are `03_L2Ecosystem`, `04_CrossChainBridges`, and `05_L2PracticalGuide`.
 - Community backlog: updated [#175](https://github.com/beihaili/Get-Started-with-Web3/issues/175#issuecomment-4483580706) so contributors can see that lesson 9-2 is complete and only lessons 9-3 to 9-5 remain in that issue.
+- Distribution planning: published `docs/strategy/2026-05-19-content-calendar.md`, defining an eight-week public content cadence and weekly theme-to-CTA mapping so shipped work consistently feeds stars/contributor growth.
 - Contributor loop: [#177](https://github.com/beihaili/Get-Started-with-Web3/pull/177) and [#178](https://github.com/beihaili/Get-Started-with-Web3/pull/178) merged, closing [#162](https://github.com/beihaili/Get-Started-with-Web3/issues/162) and [#158](https://github.com/beihaili/Get-Started-with-Web3/issues/158).
 - Community backlog: opened replacement growth starter issues [#186](https://github.com/beihaili/Get-Started-with-Web3/issues/186) and [#187](https://github.com/beihaili/Get-Started-with-Web3/issues/187), keeping the open good-first issue queue at 11.
 - GitHub triage: Dependabot PRs [#179](https://github.com/beihaili/Get-Started-with-Web3/pull/179), [#180](https://github.com/beihaili/Get-Started-with-Web3/pull/180), [#182](https://github.com/beihaili/Get-Started-with-Web3/pull/182), and [#191](https://github.com/beihaili/Get-Started-with-Web3/pull/191) landed; Node 22-only PRs [#181](https://github.com/beihaili/Get-Started-with-Web3/pull/181), [#183](https://github.com/beihaili/Get-Started-with-Web3/pull/183), and [#192](https://github.com/beihaili/Get-Started-with-Web3/pull/192) were closed with migration notes.
@@ -98,3 +99,4 @@
 - Replacement starter issue: https://github.com/beihaili/Get-Started-with-Web3/issues/187
 - AI manifest: `ai/manifest.json`
 - AI content index: `ai/content-index.json`
+- Weekly content calendar: `docs/strategy/2026-05-19-content-calendar.md`

--- a/docs/strategy/2026-05-14-execution-board.md
+++ b/docs/strategy/2026-05-14-execution-board.md
@@ -64,7 +64,7 @@ Update weekly.
 - [ ] Prioritize English proofreading for the highest-intent pages: README, Web3 Quick Start, Bitcoin, DeFi, L2, AI-native entry.
 - [x] Start Layer 2 English coverage with `en/L2CrossChain/01_WhyScaling/README.md`.
 - [x] Add second Layer 2 English translation with `en/L2CrossChain/02_RollupPrinciples/README.md`.
-- [ ] Create a content calendar with one public content theme per week.
+- [x] Create a content calendar with one public content theme per week (`docs/strategy/2026-05-19-content-calendar.md`).
 - [ ] Turn newly added content modules into changelog/release notes.
 - [ ] Add "Last updated" or freshness signals where valuable.
 

--- a/docs/strategy/2026-05-19-content-calendar.md
+++ b/docs/strategy/2026-05-19-content-calendar.md
@@ -1,0 +1,59 @@
+# Public Content Calendar (Q2 2026)
+
+**Date:** 2026-05-19  
+**Owner:** beihai + Codex  
+**Purpose:** Keep weekly public distribution consistent so product shipments translate into stars, contributors, and sponsor conversations.
+
+## Cadence Rules
+
+- Publish at least **1 primary post per week** (X/Farcaster thread or Chinese community long-form post).
+- Publish **1 supporting follow-up** per week (quote, short recap, or issue/PR call-to-action).
+- Every post must include:
+  1. one concrete learner outcome,
+  2. one canonical project link,
+  3. one contribution CTA (`star`, `issue`, `PR`, or translation help).
+- Record published links in `docs/strategy/2026-05-15-public-post-drafts.md` and summary outcomes in `docs/operations/YYYY-MM-DD-daily-report.md`.
+
+## Weekly Themes (Rolling 8 Weeks)
+
+| Week (Mon-Sun) | Core Theme | Primary Proof Asset | Primary Channel | Supporting Channel | CTA Focus |
+| --- | --- | --- | --- | --- | --- |
+| 2026-05-18 → 2026-05-24 | Layer 2 learning path progress | `en/L2CrossChain/01_WhyScaling` + `02_RollupPrinciples` + issue [#175](https://github.com/beihaili/Get-Started-with-Web3/issues/175) | X/Farcaster thread | Chinese Web3 communities | Translation contributors for 9-3/9-4/9-5 |
+| 2026-05-25 → 2026-05-31 | AI-native curriculum interface (`llms.txt` + MCP) | `ai/manifest.json`, `public/llms.txt`, local MCP demo | X/Farcaster thread | Hacker News-style dev communities | Star + AI-agent developer feedback |
+| 2026-06-01 → 2026-06-07 | Beginner-safe Web3 route | `README.md` path + module map | Chinese long-form post | X short thread | Beginner onboarding shares + stars |
+| 2026-06-08 → 2026-06-14 | Interactive learning experiences | Interactive release + Merkle/Gas lesson links | X/Farcaster thread | Chinese repost | Lesson feedback + bug reports |
+| 2026-06-15 → 2026-06-21 | Contributor highlights and first-PR journey | roadmap [#156](https://github.com/beihaili/Get-Started-with-Web3/issues/156) + spotlight docs | GitHub discussion / issue update | X/Farcaster | Good-first-issue participation |
+| 2026-06-22 → 2026-06-28 | Security and wallet safety education | security lessons + glossary references | Chinese community post | X thread | Safety content reviews + source links |
+| 2026-06-29 → 2026-07-05 | Builder tooling and practical labs | builder modules + contract examples | X/Farcaster | Dev communities | Builder examples and PRs |
+| 2026-07-06 → 2026-07-12 | Open-source progress toward 1000 stars | KPI progress + merged community PR highlights | X/Farcaster + GitHub roadmap update | Chinese repost | Stars + external contributor onboarding |
+
+## Reusable Post Structure
+
+Use this 4-block format for each weekly primary post:
+
+1. **What changed** (specific module / feature shipped this week).
+2. **Why it matters** (specific learner or builder outcome).
+3. **Where to verify** (site URL + repo/PR/release URL).
+4. **How to help** (one explicit CTA).
+
+## Metrics To Track Per Week
+
+- Stars delta (start vs end of week)
+- Forks delta
+- Number of issue comments / PR opens from non-maintainers
+- Post count and link list
+- Sponsor inquiry count (if any)
+
+## Ownership Workflow
+
+1. Monday: pick the weekly theme and draft one primary post.
+2. Wednesday: publish primary post and one supporting follow-up.
+3. Friday: record link + visible engagement + contributor outcomes.
+4. Sunday: summarize in daily report and adjust next week theme based on actual movement.
+
+## Risk Controls
+
+- No token promotion, price speculation, or trading claims.
+- Do not imply paid AI features are live before launch decision.
+- Sponsor mentions must remain factual and non-endorsement in tone.
+- If a post mentions partner names, reuse approved wording from strategy docs.


### PR DESCRIPTION
## Summary\n- add a dedicated 8-week public content calendar for weekly growth distribution\n- mark execution-board content-calendar task as complete and link the new strategy doc\n- sync the 2026-05-19 daily operations report with this new distribution artifact\n\n## Why\nThe growth loop needs predictable public distribution so shipped product work converts into stars, contributors, and sponsor conversations.\n\n## Validation\n- docs-only change; no runtime/code path impact\n- markdown reviewed for consistency with existing strategy + operations docs\n