### PR TITLE
feat: add site analytics and domain-ready URLs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,12 @@ npm run mcp:web3        # 启动本地 stdio MCP server
 
 修改课程结构、术语表或 Agent 工具元数据后，运行 `npm run ai:index && npm run ai:publish && npm run ai:verify`，并提交更新后的 `ai/` 与 `public/` artifacts。
 
+## 官网 URL、域名与统计
+
+- `src/config/siteConfig.js`: 统一管理默认官网 URL、base path、canonical/share URL 拼接；默认仍是 GitHub Pages `https://beihaili.github.io/Get-Started-with-Web3` 和 `/Get-Started-with-Web3/`。
+- 未来接入 `bhbtc.xyz` 时，构建可用 `VITE_SITE_BASE_URL=https://...` / `SITE_BASE_URL=https://...` 更新前端 canonical、sitemap、robots 和 AI artifacts；同时用 `VITE_BASE_PATH=/` 切到自定义域名根路径。不要在 DNS/GitHub Pages custom domain 未确认前提交 `public/CNAME`。
+- `index.html` 保留 GA4 和 Cloudflare Web Analytics 脚本；GA 自动初始 pageview 已关闭，由 `src/components/RouteAnalytics.jsx` + `src/utils/analytics.js` 在 SPA 路由切换时发送 `page_view`。
+
 ## 国际化与命名空间
 
 - UI 文案按页面/功能拆分在 `src/i18n/locales/{en,zh}/{section}.json`。保留 `t('section.key')` 调用方式，不要改成多 namespace 的 `t` 调用。
@@ -150,4 +156,5 @@ Agent 使用 MCP 工具回答时，应优先引用工具返回的 `citation.file
 - 新增术语时，更新 `src/config/glossaryData.js` 和对应测试，保持 `GLOSSARY_CATEGORIES` 与测试允许分类一致，再运行 `npm run ai:index`。
 - MCP 工具必须保持只读，返回结果需包含可引用的 `citation.file` 或 URL。
 - 接受 Dependabot major 更新前，先检查包的 `engines.node` 与 `.github/workflows/*.yml` 中的 Node 版本；Node 22-only 工具链更新必须作为独立迁移处理。
+- 修改官网 URL、Vite base、sitemap、robots、prerender、AI artifact public URL 或 analytics 逻辑后，优先跑 site/analytics 相关 Vitest、`npm run ai:index && npm run ai:publish && npm run ai:verify`、`npm run build`，并用浏览器 smoke 核对 canonical 与 route tracking 无控制台错误。
 - 修改代码后至少运行相关 Vitest；完成前运行 `npm test` 和 `npm run lint`。

--- a/ai/content-index.json
+++ b/ai/content-index.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2026-05-09",
-  "generatedAt": "2026-05-19T01:34:17.382Z",
+  "generatedAt": "2026-05-19T07:20:59.655Z",
   "repository": {
     "name": "Get-Started-with-Web3",
     "owner": "beihaili",

--- a/ai/llms.txt
+++ b/ai/llms.txt
@@ -4,7 +4,7 @@ This repository exposes bilingual Web3 learning content for AI agents.
 
 Source: https://github.com/beihaili/Get-Started-with-Web3
 Homepage: https://beihaili.github.io/Get-Started-with-Web3/
-Generated: 2026-05-19T01:34:17.382Z
+Generated: 2026-05-19T07:20:59.655Z
 
 ## Artifacts
 - Manifest: ai/manifest.json

--- a/ai/manifest.json
+++ b/ai/manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2026-05-09",
-  "generatedAt": "2026-05-19T01:34:17.382Z",
+  "generatedAt": "2026-05-19T07:20:59.655Z",
   "repository": {
     "name": "Get-Started-with-Web3",
     "owner": "beihaili",

--- a/docs/operations/2026-05-19-daily-report.md
+++ b/docs/operations/2026-05-19-daily-report.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-05-19
 **Owner:** beihai + Codex
-**Reporting window:** 2026-05-19 10:25 CST snapshot; GitHub timestamps are UTC unless noted.
+**Reporting window:** 2026-05-19 15:27 CST snapshot; GitHub timestamps are UTC unless noted.
 
 ## KPI Snapshot
 
@@ -12,7 +12,7 @@
 | Forks             |      58 |                  57 |       +1 | `gh repo view beihaili/Get-Started-with-Web3` |
 | Watchers          |       3 |                   3 |        0 | `gh repo view beihaili/Get-Started-with-Web3` |
 | Contributors      |      13 |                  13 |        0 | `gh api repos/.../contributors`               |
-| Open PRs          |       0 |                   0 |        0 | `gh pr list --state open`                     |
+| Open PRs          |       3 |                   0 |       +3 | `gh pr list --state open`                     |
 | Open issues       |      12 |                  12 |        0 | `gh issue list --state open --limit 200`      |
 | Good first issues |      11 |                  11 |        0 | `gh issue list` label count                   |
 
@@ -23,35 +23,37 @@
 - Translation operations: reduced local translation coverage warnings from 16 to 15; the remaining Layer 2 gaps are `03_L2Ecosystem`, `04_CrossChainBridges`, and `05_L2PracticalGuide`.
 - Community backlog: updated [#175](https://github.com/beihaili/Get-Started-with-Web3/issues/175#issuecomment-4483580706) so contributors can see that lesson 9-2 is complete and only lessons 9-3 to 9-5 remain in that issue.
 - Contributor loop: [#177](https://github.com/beihaili/Get-Started-with-Web3/pull/177) and [#178](https://github.com/beihaili/Get-Started-with-Web3/pull/178) merged, closing [#162](https://github.com/beihaili/Get-Started-with-Web3/issues/162) and [#158](https://github.com/beihaili/Get-Started-with-Web3/issues/158).
-- Community backlog: opened replacement growth starter issues [#186](https://github.com/beihaili/Get-Started-with-Web3/issues/186) and [#187](https://github.com/beihaili/Get-Started-with-Web3/issues/187), keeping the open good-first issue queue at 11.
+- Community backlog: opened replacement growth starter issues [#186](https://github.com/beihaili/Get-Started-with-Web3/issues/186) and [#187](https://github.com/beihaili/Get-Started-with-Web3/issues/187), keeping the open good-first issue queue at 11; new community PRs [#194](https://github.com/beihaili/Get-Started-with-Web3/pull/194), [#195](https://github.com/beihaili/Get-Started-with-Web3/pull/195), and [#196](https://github.com/beihaili/Get-Started-with-Web3/pull/196) are pending review.
 - GitHub triage: Dependabot PRs [#179](https://github.com/beihaili/Get-Started-with-Web3/pull/179), [#180](https://github.com/beihaili/Get-Started-with-Web3/pull/180), [#182](https://github.com/beihaili/Get-Started-with-Web3/pull/182), and [#191](https://github.com/beihaili/Get-Started-with-Web3/pull/191) landed; Node 22-only PRs [#181](https://github.com/beihaili/Get-Started-with-Web3/pull/181), [#183](https://github.com/beihaili/Get-Started-with-Web3/pull/183), and [#192](https://github.com/beihaili/Get-Started-with-Web3/pull/192) were closed with migration notes.
 - Dependency hygiene: `.github/dependabot.yml` now ignores Node 22-only major updates for `@commitlint/cli`, `@commitlint/config-conventional`, and `lint-staged` until the project intentionally migrates CI and local contributor docs from Node 20.
 - CI tooling: `actions/upload-artifact` is moving to v7 together with the workflow regression test that verifies PR build artifact comments, superseding Dependabot PR [#190](https://github.com/beihaili/Get-Started-with-Web3/pull/190).
+- Website observability/domain readiness: added centralized site URL/base-path config, SPA route-level GA `page_view` tracking, env-driven sitemap/robots/AI artifact URLs, and custom-domain-safe build knobs (`VITE_SITE_BASE_URL` / `SITE_BASE_URL`, `VITE_BASE_PATH`) without enabling CNAME or DNS changes yet.
 
 ## Deploy And Verification
 
-| Surface                  | Status  | Evidence                                                                                      | Notes                                                                                                                                     |
-| ------------------------ | ------- | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| Latest production deploy | Success | [Run 26071964424](https://github.com/beihaili/Get-Started-with-Web3/actions/runs/26071964424) | Main deploy for [#189](https://github.com/beihaili/Get-Started-with-Web3/pull/189) completed successfully; latest recorded head `5fadf34` |
-| Public lesson route      | Success | `curl -L .../en/learn/module-9/9-2`                                                           | HTTP 200 and prerendered HTML contains `Rollup Principles Explained`                                                                      |
-| Translation coverage     | Success | `npm run translation:check`                                                                   | 15 missing-English warnings remain after adding lesson 9-2                                                                                |
-| AI index                 | Success | `npm run ai:index`, `npm run ai:publish`                                                      | 11 modules, 108 lesson entries, 57 glossary entries                                                                                       |
-| AI entrypoints           | Success | `npm run ai:verify`                                                                           | Source/public artifacts, MCP tools, `llms.txt`, and x402 metadata pass                                                                    |
-| Test suite               | Success | `npm test`                                                                                    | 40 test files and 217 tests passed                                                                                                        |
-| Lint                     | Success | `npm run lint`                                                                                | ESLint completed with zero reported errors                                                                                                |
-| Production build         | Success | `npm run build`                                                                               | Vite build plus 131/131 prerendered routes passed, including `/en/learn/module-9/9-2`                                                     |
-| Formatting               | Success | `npx prettier --check ...`                                                                    | Changed Markdown files use Prettier style                                                                                                 |
-| Whitespace               | Success | `git diff --check`                                                                            | No whitespace errors                                                                                                                      |
+| Surface                  | Status  | Evidence                                                                                      | Notes                                                                                                         |
+| ------------------------ | ------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Latest production deploy | Success | [Run 26072572474](https://github.com/beihaili/Get-Started-with-Web3/actions/runs/26072572474) | Latest main deploy completed successfully for head `94c1729`                                                  |
+| Public lesson route      | Success | `curl -L .../en/learn/module-9/9-2`                                                           | HTTP 200 and prerendered HTML contains `Rollup Principles Explained`                                          |
+| Translation coverage     | Success | `npm run translation:check`                                                                   | 15 missing-English warnings remain after adding lesson 9-2                                                    |
+| AI index                 | Success | `npm run ai:index`, `npm run ai:publish`                                                      | 11 modules, 108 lesson entries, 57 glossary entries                                                           |
+| AI entrypoints           | Success | `npm run ai:verify`                                                                           | Source/public artifacts, MCP tools, `llms.txt`, and x402 metadata pass                                        |
+| Site analytics/domain    | Success | Targeted Vitest + local preview browser smoke                                                 | Custom-domain URL helpers, route-level pageview tracking, canonical updates, sitemap, and robots pass locally |
+| Test suite               | Success | `npm test`                                                                                    | 43 test files and 226 tests passed                                                                            |
+| Lint                     | Success | `npm run lint`                                                                                | ESLint completed with zero reported errors                                                                    |
+| Production build         | Success | `npm run build`                                                                               | Vite build plus 131/131 prerendered routes passed, including `/en/learn/module-9/9-2`                         |
+| Formatting               | Success | `npx prettier --check ...`                                                                    | Changed Markdown files use Prettier style                                                                     |
+| Whitespace               | Success | `git diff --check`                                                                            | No whitespace errors                                                                                          |
 
 ## External Distribution
 
-| Target                       | Status  | Evidence                                                                                            | Next action                                                           |
-| ---------------------------- | ------- | --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| GitHub contributor backlog   | Updated | [#175 update](https://github.com/beihaili/Get-Started-with-Web3/issues/175#issuecomment-4483580706) | Remaining L2 translation work is now lessons 9-3 to 9-5               |
-| GitHub PR queue              | Clear   | `gh pr list --state open`                                                                           | Revisit Node 22-only dev-tool majors during planned Node 22 migration |
-| Twitter/X and Farcaster post | Ready   | `docs/strategy/2026-05-15-public-post-drafts.md`                                                    | Publish Draft 3 from beihai account                                   |
-| learnblockchain.cn/community | Ready   | `docs/strategy/2026-05-15-public-post-drafts.md`                                                    | Publish Chinese community post when convenient                        |
-| TensorBlock awesome MCP      | Waiting | [PR #544](https://github.com/TensorBlock/awesome-mcp-servers/pull/544)                              | Avoid repeat pings until reviewer responds                            |
+| Target                       | Status  | Evidence                                                                                                                                                                                                   | Next action                                                                  |
+| ---------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| GitHub contributor backlog   | Updated | [#175 update](https://github.com/beihaili/Get-Started-with-Web3/issues/175#issuecomment-4483580706)                                                                                                        | Remaining L2 translation work is now lessons 9-3 to 9-5                      |
+| GitHub PR queue              | Review  | [#194](https://github.com/beihaili/Get-Started-with-Web3/pull/194), [#195](https://github.com/beihaili/Get-Started-with-Web3/pull/195), [#196](https://github.com/beihaili/Get-Started-with-Web3/pull/196) | Review #194/#195 checks; #196 is currently DIRTY and needs conflict handling |
+| Twitter/X and Farcaster post | Ready   | `docs/strategy/2026-05-15-public-post-drafts.md`                                                                                                                                                           | Publish Draft 3 from beihai account                                          |
+| learnblockchain.cn/community | Ready   | `docs/strategy/2026-05-15-public-post-drafts.md`                                                                                                                                                           | Publish Chinese community post when convenient                               |
+| TensorBlock awesome MCP      | Waiting | [PR #544](https://github.com/TensorBlock/awesome-mcp-servers/pull/544)                                                                                                                                     | Avoid repeat pings until reviewer responds                                   |
 
 ## Sponsor And Revenue
 
@@ -65,22 +67,24 @@
 ## Blockers And Risks
 
 - Growth remains flat at 614 stars; the next growth move needs actual public distribution, not only internal content shipping.
+- Community PR queue reopened with 3 external PRs; #196 overlaps the remaining Layer 2 translation work and is currently marked DIRTY, so review and conflict triage are needed before merging.
 - Dependabot queue is controlled, but Node 22 migration remains a technical stewardship item before accepting `@commitlint/cli` v21, `@commitlint/config-conventional` v21, or `lint-staged` v17.
 - Layer 2 English coverage improves, but three lessons still remain after this branch; broader DAO and non-core docs still need translation or classification.
 - Sponsor outreach remains drafted but unsent; actual external sending still needs a confirmed human channel or connector.
+- `bhbtc.xyz` activation is prepared in code but not enabled; exact host, DNS provider setup, and GitHub Pages custom-domain readiness need confirmation before adding `public/CNAME` or changing Pages settings.
 - Hosted payment, x402 enforcement, affiliate expansion, wallet flows, and payment-address changes still require explicit user confirmation.
 
 ## Next Operating Block
 
-1. Continue the remaining Layer 2 English translations with `L2CrossChain/03_L2Ecosystem`, or leave it open for contributors if #175 gets picked up.
-2. Plan the Node 22 migration separately before accepting `@commitlint/cli` v21, `@commitlint/config-conventional` v21, or `lint-staged` v17.
+1. Finish PR/deploy for analytics/domain-readiness, then confirm production still serves GitHub Pages paths correctly.
+2. Review community PRs #194, #195, and #196; handle #196 conflicts before deciding whether it closes #175.
 3. Publish the ready X/Farcaster and Chinese community posts so the new content work feeds the 1000-star growth loop.
 
 ## Evidence Links
 
 - Repository: https://github.com/beihaili/Get-Started-with-Web3
 - Production site: https://beihaili.github.io/Get-Started-with-Web3/
-- Latest recorded main deploy: https://github.com/beihaili/Get-Started-with-Web3/actions/runs/26071964424
+- Latest recorded main deploy: https://github.com/beihaili/Get-Started-with-Web3/actions/runs/26072572474
 - Remaining L2 translation starter issue: https://github.com/beihaili/Get-Started-with-Web3/issues/175
 - Remaining L2 translation issue update: https://github.com/beihaili/Get-Started-with-Web3/issues/175#issuecomment-4483580706
 - First L2 English translation PR: https://github.com/beihaili/Get-Started-with-Web3/pull/174
@@ -96,5 +100,11 @@
 - Closed Node 22-only commitlint config PR: https://github.com/beihaili/Get-Started-with-Web3/pull/192
 - Replacement starter issue: https://github.com/beihaili/Get-Started-with-Web3/issues/186
 - Replacement starter issue: https://github.com/beihaili/Get-Started-with-Web3/issues/187
+- Open community PR: https://github.com/beihaili/Get-Started-with-Web3/pull/194
+- Open community PR: https://github.com/beihaili/Get-Started-with-Web3/pull/195
+- Open community PR: https://github.com/beihaili/Get-Started-with-Web3/pull/196
+- Analytics/domain-readiness branch: `codex/site-analytics-domain-readiness`
+- Site config: `src/config/siteConfig.js`
+- Route analytics: `src/components/RouteAnalytics.jsx`
 - AI manifest: `ai/manifest.json`
 - AI content index: `ai/content-index.json`

--- a/docs/strategy/2026-05-14-execution-board.md
+++ b/docs/strategy/2026-05-14-execution-board.md
@@ -6,16 +6,16 @@
 
 ## Current Snapshot
 
-| Area             | Status                | Next Action                                                                                      |
-| ---------------- | --------------------- | ------------------------------------------------------------------------------------------------ |
-| Technical health | Healthy               | Keep `npm test`, `npm run lint`, `npm run ai:verify` green and plan Node 22 migration separately |
-| GitHub growth    | Under-monetized       | Improve README conversion and launch distribution campaigns                                      |
-| SEO              | Partially implemented | Fix language metadata and route coverage                                                         |
-| English content  | Incomplete            | Close 15 missing translations or classify non-course docs                                        |
-| AI-native layer  | Strong MVP            | Productize story and prepare paid-tool landing                                                   |
-| Monetization     | Passive only          | Create sponsor kit and sponsor outreach drafts                                                   |
-| Community        | Converting            | Keep accepted contributor PRs moving into recognition and backlog refresh                        |
-| Personal brand   | Underused             | Convert every shipment into public posts and distribution assets                                 |
+| Area             | Status                | Next Action                                                                                            |
+| ---------------- | --------------------- | ------------------------------------------------------------------------------------------------------ |
+| Technical health | Healthy               | Ship analytics/domain-readiness safely, keep verification green, and plan Node 22 migration separately |
+| GitHub growth    | Under-monetized       | Improve README conversion and launch distribution campaigns                                            |
+| SEO              | Partially implemented | Fix language metadata and route coverage                                                               |
+| English content  | Incomplete            | Close 15 missing translations or classify non-course docs                                              |
+| AI-native layer  | Strong MVP            | Productize story and prepare paid-tool landing                                                         |
+| Monetization     | Passive only          | Create sponsor kit and sponsor outreach drafts                                                         |
+| Community        | Converting            | Keep accepted contributor PRs moving into recognition and backlog refresh                              |
+| Personal brand   | Underused             | Convert every shipment into public posts and distribution assets                                       |
 
 ## KPI Board
 
@@ -52,6 +52,7 @@ Update weekly.
 - [x] Fix `html lang`, `og:locale`, Twitter metadata, and JSON-LD language for `/en` pages.
 - [x] Ensure `/zh`, `/en`, `/glossary`, `/articles`, lesson pages, `llms.txt`, and AI artifact URLs are easy to discover.
 - [x] Add `glossary` routes to `scripts/generate-sitemap.mjs` and `scripts/prerender.mjs` if still missing.
+- [x] Add custom-domain-ready canonical, sitemap, robots, and AI artifact URL configuration without activating CNAME before DNS confirmation.
 - [ ] Check public prerendered HTML after build.
 - [x] Create `docs/strategy/awesome-list-submissions.md`.
 - [x] Draft submissions to Web3, Bitcoin, blockchain, open-source education, and AI-agent resource lists.
@@ -111,6 +112,7 @@ Update weekly.
 - [x] Add `sync-content` fallback coverage so English lessons do not ship broken local image references when the corresponding Chinese assets exist.
 - [x] Prepare PR build artifact comments for [#40](https://github.com/beihaili/Get-Started-with-Web3/issues/40) so contributors can download reviewed builds from the Actions run.
 - [x] Clear the 2026-05-19 Dependabot queue; merge Node-20-compatible updates, accept `actions/upload-artifact` v7 with a matching workflow test update, and close Node-22-only majors with notes.
+- [x] Add SPA route-level GA pageview tracking and centralized site URL/base-path config for future `bhbtc.xyz` activation.
 - [ ] Plan Node 22 migration before accepting `@commitlint/cli` v21, `@commitlint/config-conventional` v21, or `lint-staged` v17.
 - [ ] Run `npm test`, `npm run lint`, and `npm run ai:verify` before claiming work is complete.
 - [x] Expose translation coverage checks through `npm run translation:check`.
@@ -179,3 +181,4 @@ Daily report should include:
 | 2026-05-19 | Replenished starter backlog and synced glossary artifacts                                       | [#177](https://github.com/beihaili/Get-Started-with-Web3/pull/177) and [#178](https://github.com/beihaili/Get-Started-with-Web3/pull/178) landed, closing [#162](https://github.com/beihaili/Get-Started-with-Web3/issues/162) and [#158](https://github.com/beihaili/Get-Started-with-Web3/issues/158); opened growth starter issues [#186](https://github.com/beihaili/Get-Started-with-Web3/issues/186) and [#187](https://github.com/beihaili/Get-Started-with-Web3/issues/187); regenerated AI artifacts to 57 glossary entries |
 | 2026-05-19 | Cleared Dependabot queue                                                                        | Merged Node-20-compatible [#182](https://github.com/beihaili/Get-Started-with-Web3/pull/182) after local `npm run lint` and `npm test`; closed Node-22-only [#181](https://github.com/beihaili/Get-Started-with-Web3/pull/181) and [#183](https://github.com/beihaili/Get-Started-with-Web3/pull/183); added Dependabot ignore rules for those major lines until a planned Node 22 migration                                                                                                                                         |
 | 2026-05-19 | Completed second Dependabot follow-up                                                           | Merged Node-20-compatible [#191](https://github.com/beihaili/Get-Started-with-Web3/pull/191), closed Node-22-only [#192](https://github.com/beihaili/Get-Started-with-Web3/pull/192), and superseded failing [#190](https://github.com/beihaili/Get-Started-with-Web3/pull/190) by updating `actions/upload-artifact` and the matching workflow test together                                                                                                                                                                        |
+| 2026-05-19 | Prepared website analytics and `bhbtc.xyz` readiness                                            | Added centralized site URL/base-path config, route-level GA pageview tracking, env-driven sitemap/robots/AI artifact URL generation, and documented that CNAME/DNS activation still needs confirmation before changing GitHub Pages custom domain settings                                                                                                                                                                                                                                                                           |

--- a/index.html
+++ b/index.html
@@ -17,56 +17,74 @@
     <title>Web3 Starter - 从入门到精通</title>
 
     <!-- SEO基础标签 -->
-    <meta name="description" content="Web3和区块链入门教程平台，提供Web3快速入门、比特币技术深度解析等优质内容。21讲比特币技术+6讲Web3入门，系统化学习路径，游戏化学习体验。">
-    <meta name="keywords" content="Web3, 区块链, 比特币, 教程, 入门, blockchain, bitcoin, tutorial, 加密货币, cryptocurrency, 以太坊, ethereum">
-    <meta name="author" content="Bei Hai">
-    <link rel="canonical" href="https://beihaili.github.io/Get-Started-with-Web3/">
+    <meta
+      name="description"
+      content="Web3和区块链入门教程平台，提供Web3快速入门、比特币技术深度解析等优质内容。21讲比特币技术+6讲Web3入门，系统化学习路径，游戏化学习体验。"
+    />
+    <meta
+      name="keywords"
+      content="Web3, 区块链, 比特币, 教程, 入门, blockchain, bitcoin, tutorial, 加密货币, cryptocurrency, 以太坊, ethereum"
+    />
+    <meta name="author" content="Bei Hai" />
+    <link rel="canonical" href="https://beihaili.github.io/Get-Started-with-Web3/" />
 
     <!-- Open Graph (社交分享) -->
-    <meta property="og:title" content="Get Started With Web3 - Web3区块链入门教程">
-    <meta property="og:description" content="开源Web3教育平台，系统化学习Web3和比特币技术。包含21讲比特币技术课程和6讲Web3快速入门。">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://beihaili.github.io/Get-Started-with-Web3/">
-    <meta property="og:site_name" content="Get Started With Web3">
-    <meta property="og:locale" content="zh_CN">
-    <meta property="og:image" content="https://beihaili.github.io/Get-Started-with-Web3/logo.png">
-    <meta property="og:image:width" content="512">
-    <meta property="og:image:height" content="512">
+    <meta property="og:title" content="Get Started With Web3 - Web3区块链入门教程" />
+    <meta
+      property="og:description"
+      content="开源Web3教育平台，系统化学习Web3和比特币技术。包含21讲比特币技术课程和6讲Web3快速入门。"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://beihaili.github.io/Get-Started-with-Web3/" />
+    <meta property="og:site_name" content="Get Started With Web3" />
+    <meta property="og:locale" content="zh_CN" />
+    <meta property="og:image" content="https://beihaili.github.io/Get-Started-with-Web3/logo.png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
 
     <!-- Twitter Card -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:site" content="@bhbtc1337">
-    <meta name="twitter:title" content="Get Started With Web3 - Web3区块链入门教程">
-    <meta name="twitter:description" content="开源Web3教育平台，系统化学习Web3和比特币技术">
-    <meta name="twitter:image" content="https://beihaili.github.io/Get-Started-with-Web3/logo.png">
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@bhbtc1337" />
+    <meta name="twitter:title" content="Get Started With Web3 - Web3区块链入门教程" />
+    <meta name="twitter:description" content="开源Web3教育平台，系统化学习Web3和比特币技术" />
+    <meta
+      name="twitter:image"
+      content="https://beihaili.github.io/Get-Started-with-Web3/logo.png"
+    />
 
     <!-- Google Analytics 4 -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-91JXFFZKRV"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
+      function gtag() {
+        dataLayer.push(arguments);
+      }
       gtag('js', new Date());
-      gtag('config', 'G-91JXFFZKRV');
+      gtag('config', 'G-91JXFFZKRV', { send_page_view: false });
     </script>
 
     <!-- Cloudflare Web Analytics -->
-    <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "e9421c23377646fd87f949f35958cbf6"}'></script>
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token": "e9421c23377646fd87f949f35958cbf6"}'
+    ></script>
 
     <!-- Favicon -->
-    <link rel="icon" type="image/svg+xml" href="/Get-Started-with-Web3/favicon.svg">
+    <link rel="icon" type="image/svg+xml" href="/Get-Started-with-Web3/favicon.svg" />
 
     <!-- PWA相关 -->
-    <link rel="manifest" href="/Get-Started-with-Web3/manifest.json">
-    <meta name="theme-color" content="#0f172a">
-    <meta name="mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-    <link rel="apple-touch-icon" href="/Get-Started-with-Web3/logo.png">
+    <link rel="manifest" href="/Get-Started-with-Web3/manifest.json" />
+    <meta name="theme-color" content="#0f172a" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <link rel="apple-touch-icon" href="/Get-Started-with-Web3/logo.png" />
   </head>
   <body>
     <!-- SPA路由恢复脚本 -->
     <script>
-      (function() {
+      (function () {
         var redirect = sessionStorage.redirect;
         delete sessionStorage.redirect;
         if (redirect && redirect !== location.href) {

--- a/public/ai/content-index.json
+++ b/public/ai/content-index.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2026-05-09",
-  "generatedAt": "2026-05-19T01:34:17.382Z",
+  "generatedAt": "2026-05-19T07:20:59.655Z",
   "repository": {
     "name": "Get-Started-with-Web3",
     "owner": "beihaili",

--- a/public/ai/manifest.json
+++ b/public/ai/manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2026-05-09",
-  "generatedAt": "2026-05-19T01:34:17.382Z",
+  "generatedAt": "2026-05-19T07:20:59.655Z",
   "repository": {
     "name": "Get-Started-with-Web3",
     "owner": "beihaili",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -4,7 +4,7 @@ This repository exposes bilingual Web3 learning content for AI agents.
 
 Source: https://github.com/beihaili/Get-Started-with-Web3
 Homepage: https://beihaili.github.io/Get-Started-with-Web3/
-Generated: 2026-05-19T01:34:17.382Z
+Generated: 2026-05-19T07:20:59.655Z
 
 ## Artifacts
 - Manifest: ai/manifest.json

--- a/scripts/__tests__/seo-route-coverage.test.js
+++ b/scripts/__tests__/seo-route-coverage.test.js
@@ -1,3 +1,5 @@
+/* global process */
+
 import { readFile } from 'fs/promises';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
@@ -15,5 +17,25 @@ describe('SEO route coverage', () => {
 
     expect(sitemapScript).toContain("'/glossary'");
     expect(prerenderScript).toContain('`/${lang}/glossary`');
+  });
+
+  it('keeps robots.txt sitemap URLs aligned with the configured public site base', async () => {
+    const sitemapScript = await readFile(
+      path.join(process.cwd(), 'scripts/generate-sitemap.mjs'),
+      'utf8'
+    );
+
+    expect(sitemapScript).toContain("join(DIST_DIR, 'robots.txt')");
+    expect(sitemapScript).toContain("buildSiteUrl('/sitemap.xml', baseUrl)");
+  });
+
+  it('keeps prerender URLs aligned with the configured Vite base path', async () => {
+    const prerenderScript = await readFile(
+      path.join(process.cwd(), 'scripts/prerender.mjs'),
+      'utf8'
+    );
+
+    expect(prerenderScript).toContain('normalizeBasePath(process.env.VITE_BASE_PATH)');
+    expect(prerenderScript).toContain('BASE_PATH && url.startsWith(BASE_PATH)');
   });
 });

--- a/scripts/ai-content-core.mjs
+++ b/scripts/ai-content-core.mjs
@@ -8,15 +8,18 @@ import {
   GITHUB_REPO,
   GITHUB_USERNAME,
 } from '../src/config/courseData.js';
+import { buildSiteUrl, normalizeSiteBaseUrl } from '../src/config/siteConfig.js';
 
 export const AI_SCHEMA_VERSION = '2026-05-09';
 export const LANGUAGES = ['zh', 'en'];
-export const SITE_BASE_URL = 'https://beihaili.github.io/Get-Started-with-Web3';
+export const SITE_BASE_URL = normalizeSiteBaseUrl(
+  process.env.SITE_BASE_URL || process.env.VITE_SITE_BASE_URL
+);
 export const GITHUB_BASE_URL = `https://github.com/${GITHUB_USERNAME}/${GITHUB_REPO}/blob/${GITHUB_BRANCH}`;
 export const PUBLIC_AI_ENTRYPOINTS = {
-  llmsTxt: `${SITE_BASE_URL}/llms.txt`,
-  manifest: `${SITE_BASE_URL}/ai/manifest.json`,
-  contentIndex: `${SITE_BASE_URL}/ai/content-index.json`,
+  llmsTxt: buildSiteUrl('/llms.txt', SITE_BASE_URL),
+  manifest: buildSiteUrl('/ai/manifest.json', SITE_BASE_URL),
+  contentIndex: buildSiteUrl('/ai/content-index.json', SITE_BASE_URL),
 };
 
 export const LOCAL_MCP_CLIENT_CONFIG = {
@@ -173,7 +176,7 @@ export async function buildAiIndex(options = {}) {
         siteUrls: Object.fromEntries(
           LANGUAGES.map((lang) => [
             lang,
-            `${SITE_BASE_URL}/${lang}/learn/${module.id}/${lesson.id}`,
+            buildSiteUrl(`/${lang}/learn/${module.id}/${lesson.id}`, SITE_BASE_URL),
           ])
         ),
       });
@@ -189,7 +192,7 @@ export async function buildAiIndex(options = {}) {
       name: GITHUB_REPO,
       owner: GITHUB_USERNAME,
       branch: GITHUB_BRANCH,
-      homepage: `${SITE_BASE_URL}/`,
+      homepage: buildSiteUrl('/', SITE_BASE_URL),
       sourceUrl: `https://github.com/${GITHUB_USERNAME}/${GITHUB_REPO}`,
     },
     languages: LANGUAGES,
@@ -203,7 +206,7 @@ export async function buildAiIndex(options = {}) {
       citation: {
         file: 'src/config/glossaryData.js',
         githubUrl: `${GITHUB_BASE_URL}/src/config/glossaryData.js`,
-        siteUrl: `${SITE_BASE_URL}/zh/glossary`,
+        siteUrl: buildSiteUrl('/zh/glossary', SITE_BASE_URL),
       },
     })),
     tools: TOOL_CATALOG,
@@ -466,7 +469,7 @@ function buildCitation(lang, moduleId, lessonId, relativePath) {
   return {
     file: normalized,
     githubUrl: `${GITHUB_BASE_URL}/${encodeURI(normalized).replace(/#/g, '%23')}`,
-    siteUrl: `${SITE_BASE_URL}/${lang}/learn/${moduleId}/${lessonId}`,
+    siteUrl: buildSiteUrl(`/${lang}/learn/${moduleId}/${lessonId}`, SITE_BASE_URL),
   };
 }
 

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -9,10 +9,11 @@
 import { readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { buildSiteUrl, normalizeSiteBaseUrl } from '../src/config/siteConfig.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DIST_DIR = join(__dirname, '..', 'dist');
-const BASE_URL = 'https://beihaili.github.io/Get-Started-with-Web3';
+const BASE_URL = normalizeSiteBaseUrl(process.env.SITE_BASE_URL || process.env.VITE_SITE_BASE_URL);
 
 // 支持的语言前缀
 const LANGS = ['zh', 'en'];
@@ -79,6 +80,14 @@ ${urlEntries}
 `;
 }
 
+function buildRobotsTxt(baseUrl) {
+  return `User-agent: *
+Allow: /
+
+Sitemap: ${buildSiteUrl('/sitemap.xml', baseUrl)}
+`;
+}
+
 function generateSitemap() {
   const learnRoutes = getLearnRoutes();
   console.log(`[sitemap] Found ${learnRoutes.length} learn routes from courseData`);
@@ -88,12 +97,12 @@ function generateSitemap() {
   for (const lang of LANGS) {
     // 静态页面：/zh, /zh/dashboard, /zh/badges, …
     for (const page of STATIC_PAGES) {
-      allUrls.push(`${BASE_URL}/${lang}${page}`);
+      allUrls.push(buildSiteUrl(`/${lang}${page}`, BASE_URL));
     }
 
     // 课程详情页：/zh/learn/module-1/1-1, …
     for (const route of learnRoutes) {
-      allUrls.push(`${BASE_URL}/${lang}${route}`);
+      allUrls.push(buildSiteUrl(`/${lang}${route}`, BASE_URL));
     }
   }
 
@@ -107,6 +116,11 @@ function generateSitemap() {
   writeFileSync(outputPath, xml, 'utf-8');
 
   console.log(`[sitemap] Written to ${outputPath}`);
+
+  const robotsPath = join(DIST_DIR, 'robots.txt');
+  writeFileSync(robotsPath, buildRobotsTxt(BASE_URL), 'utf-8');
+
+  console.log(`[robots] Written to ${robotsPath}`);
 }
 
 generateSitemap();

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -11,10 +11,11 @@ import { createServer } from 'http';
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { normalizeBasePath } from '../src/config/siteConfig.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DIST_DIR = join(__dirname, '..', 'dist');
-const BASE_PATH = '/Get-Started-with-Web3';
+const BASE_PATH = normalizeBasePath(process.env.VITE_BASE_PATH).replace(/\/$/, '');
 const PORT = 4173;
 
 // 从 courseData 动态生成路由列表（支持 i18n 语言前缀）
@@ -83,7 +84,7 @@ function createStaticServer() {
     let url = req.url;
 
     // 去掉 base path
-    if (url.startsWith(BASE_PATH)) {
+    if (BASE_PATH && url.startsWith(BASE_PATH)) {
       url = url.slice(BASE_PATH.length) || '/';
     }
 
@@ -144,9 +145,7 @@ async function prerender() {
 
       // 确定输出路径
       const outputPath =
-        route === '/'
-          ? join(DIST_DIR, 'index.html')
-          : join(DIST_DIR, route.slice(1), 'index.html');
+        route === '/' ? join(DIST_DIR, 'index.html') : join(DIST_DIR, route.slice(1), 'index.html');
 
       // 创建目录
       const outputDir = dirname(outputPath);
@@ -168,7 +167,9 @@ async function prerender() {
   await browser.close();
   server.close();
 
-  console.log(`\n[prerender] Done: ${success} succeeded, ${failed} failed out of ${routes.length} routes`);
+  console.log(
+    `\n[prerender] Done: ${success} succeeded, ${failed} failed out of ${routes.length} routes`
+  );
 
   if (failed > 0) {
     process.exit(1);

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,6 +1,7 @@
 import { Component } from 'react';
 import { Translation } from 'react-i18next';
 import { AlertTriangle } from 'lucide-react';
+import { APP_BASE_PATH, joinBasePath } from '../config/siteConfig';
 
 class ErrorBoundary extends Component {
   constructor(props) {
@@ -35,7 +36,7 @@ class ErrorBoundary extends Component {
                     {t('error.reload')}
                   </button>
                   <a
-                    href="/Get-Started-with-Web3/"
+                    href={joinBasePath(APP_BASE_PATH, '/')}
                     aria-label={t('error.backHomeLabel')}
                     className="px-6 py-2 bg-slate-800 hover:bg-slate-700 text-white rounded-lg transition-colors"
                   >

--- a/src/components/RouteAnalytics.jsx
+++ b/src/components/RouteAnalytics.jsx
@@ -1,0 +1,18 @@
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
+import { trackPageView } from '../utils/analytics';
+
+export default function RouteAnalytics() {
+  const location = useLocation();
+  const lastTrackedPath = useRef(null);
+
+  useEffect(() => {
+    const routeKey = `${location.pathname}${location.search}${location.hash}`;
+    if (lastTrackedPath.current === routeKey) return;
+
+    lastTrackedPath.current = routeKey;
+    trackPageView(location);
+  }, [location]);
+
+  return null;
+}

--- a/src/components/ShareCard.jsx
+++ b/src/components/ShareCard.jsx
@@ -4,6 +4,7 @@ import { Download, X, Share2 } from 'lucide-react';
 import html2canvas from 'html2canvas';
 import { useUserStore } from '../store/useUserStore';
 import { ACHIEVEMENT_BADGES } from '../features/badges';
+import { buildSiteUrl } from '../config/siteConfig';
 
 const ShareCard = ({ onClose }) => {
   const { t } = useTranslation();
@@ -51,7 +52,7 @@ const ShareCard = ({ onClose }) => {
       plural: earnedCount > 1 ? 's' : '',
       xp: totalExperience,
     });
-    const url = 'https://beihaili.github.io/Get-Started-with-Web3/';
+    const url = buildSiteUrl('/');
     window.open(
       `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`,
       '_blank'

--- a/src/components/__tests__/RouteAnalytics.test.jsx
+++ b/src/components/__tests__/RouteAnalytics.test.jsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import RouteAnalytics from '../RouteAnalytics';
+
+const TestNavigator = () => {
+  const navigate = useNavigate();
+  return <button onClick={() => navigate('/en/dashboard?source=test')}>Go dashboard</button>;
+};
+
+describe('RouteAnalytics', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    document.title = 'Route Analytics Test';
+  });
+
+  it('tracks the first route and subsequent SPA navigation', async () => {
+    const gtag = vi.fn();
+    vi.stubGlobal('gtag', gtag);
+
+    render(
+      <MemoryRouter initialEntries={['/en']}>
+        <RouteAnalytics />
+        <Routes>
+          <Route path="/en" element={<TestNavigator />} />
+          <Route path="/en/dashboard" element={<TestNavigator />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(gtag).toHaveBeenCalledTimes(1));
+    expect(gtag).toHaveBeenLastCalledWith(
+      'event',
+      'page_view',
+      expect.objectContaining({
+        page_path: '/Get-Started-with-Web3/en',
+      })
+    );
+
+    fireEvent.click(document.querySelector('button'));
+
+    await waitFor(() => expect(gtag).toHaveBeenCalledTimes(2));
+    expect(gtag).toHaveBeenLastCalledWith(
+      'event',
+      'page_view',
+      expect.objectContaining({
+        page_path: '/Get-Started-with-Web3/en/dashboard?source=test',
+      })
+    );
+  });
+});

--- a/src/config/__tests__/siteConfig.test.js
+++ b/src/config/__tests__/siteConfig.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { buildSiteUrl, joinBasePath, normalizeBasePath, normalizeSiteBaseUrl } from '../siteConfig';
+
+describe('siteConfig', () => {
+  it('normalizes custom site origins without trailing slashes', () => {
+    expect(normalizeSiteBaseUrl('https://web3.bhbtc.xyz/')).toBe('https://web3.bhbtc.xyz');
+    expect(normalizeSiteBaseUrl(' https://learn.bhbtc.xyz/// ')).toBe('https://learn.bhbtc.xyz');
+  });
+
+  it('builds canonical URLs from the configured site base', () => {
+    expect(buildSiteUrl('/en/dashboard', 'https://web3.bhbtc.xyz/')).toBe(
+      'https://web3.bhbtc.xyz/en/dashboard'
+    );
+    expect(
+      buildSiteUrl('/en/learn/module-9/9-2?from=share#rollups', 'https://web3.bhbtc.xyz/')
+    ).toBe('https://web3.bhbtc.xyz/en/learn/module-9/9-2?from=share#rollups');
+  });
+
+  it('keeps the repository base path explicit for GitHub Pages assets and analytics paths', () => {
+    expect(normalizeBasePath('Get-Started-with-Web3')).toBe('/Get-Started-with-Web3/');
+    expect(joinBasePath('/Get-Started-with-Web3/', '/en/glossary')).toBe(
+      '/Get-Started-with-Web3/en/glossary'
+    );
+    expect(joinBasePath('/', '/en/glossary')).toBe('/en/glossary');
+  });
+});

--- a/src/config/siteConfig.js
+++ b/src/config/siteConfig.js
@@ -1,0 +1,30 @@
+export const DEFAULT_SITE_BASE_URL = 'https://beihaili.github.io/Get-Started-with-Web3';
+export const DEFAULT_BASE_PATH = '/Get-Started-with-Web3/';
+
+export function normalizeSiteBaseUrl(value, fallback = DEFAULT_SITE_BASE_URL) {
+  const raw = String(value || fallback).trim();
+  return raw.replace(/\/+$/, '');
+}
+
+export function normalizeBasePath(value, fallback = DEFAULT_BASE_PATH) {
+  const raw = String(value || fallback).trim();
+  if (!raw || raw === '/') return '/';
+  return `/${raw.replace(/^\/+|\/+$/g, '')}/`;
+}
+
+export function joinBasePath(basePath, routePath = '/') {
+  const normalizedBasePath = normalizeBasePath(basePath);
+  const normalizedRoute = `/${String(routePath || '/').replace(/^\/+/, '')}`;
+  if (normalizedBasePath === '/') return normalizedRoute;
+  return `${normalizedBasePath.replace(/\/$/, '')}${normalizedRoute}`;
+}
+
+export function buildSiteUrl(routePath = '/', siteBaseUrl = DEFAULT_SITE_BASE_URL) {
+  const baseUrl = normalizeSiteBaseUrl(siteBaseUrl);
+  const normalizedRoute = `/${String(routePath || '/').replace(/^\/+/, '')}`;
+  if (normalizedRoute === '/') return `${baseUrl}/`;
+  return `${baseUrl}${normalizedRoute}`;
+}
+
+export const SITE_BASE_URL = normalizeSiteBaseUrl(import.meta.env?.VITE_SITE_BASE_URL);
+export const APP_BASE_PATH = normalizeBasePath(import.meta.env?.VITE_BASE_PATH);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -13,7 +13,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
 // Register service worker
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/Get-Started-with-Web3/sw.js').catch(() => {
+    navigator.serviceWorker.register(`${import.meta.env.BASE_URL}sw.js`).catch(() => {
       // SW registration failed silently — app works without it
     });
   });

--- a/src/pages/ArticlesPage.jsx
+++ b/src/pages/ArticlesPage.jsx
@@ -5,6 +5,7 @@ import { BookOpen, ArrowLeft, ExternalLink } from 'lucide-react';
 import { COURSE_DATA } from '../config/courseData';
 import SeoHead from '../components/SeoHead';
 import LanguageSwitcher from '../components/LanguageSwitcher';
+import { buildSiteUrl } from '../config/siteConfig';
 
 /**
  * SEO-friendly articles index page.
@@ -17,9 +18,9 @@ const ArticlesPage = () => {
 
   const totalLessons = COURSE_DATA.reduce((sum, mod) => sum + mod.lessons.length, 0);
 
-  const canonicalUrl = `https://beihaili.github.io/Get-Started-with-Web3/${lang}/articles`;
+  const canonicalUrl = buildSiteUrl(`/${lang}/articles`);
   const altLang = lang === 'en' ? 'zh' : 'en';
-  const alternateUrl = `https://beihaili.github.io/Get-Started-with-Web3/${altLang}/articles`;
+  const alternateUrl = buildSiteUrl(`/${altLang}/articles`);
 
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-slate-950">

--- a/src/pages/BadgeCollectionPage.jsx
+++ b/src/pages/BadgeCollectionPage.jsx
@@ -7,6 +7,7 @@ import { BadgeCard, ACHIEVEMENT_BADGES, SPECIAL_BADGES } from '../features/badge
 import ShareCard from '../components/ShareCard';
 import LanguageSwitcher from '../components/LanguageSwitcher';
 import SeoHead from '../components/SeoHead';
+import { buildSiteUrl } from '../config/siteConfig';
 
 /**
  * 徽章收藏页面
@@ -22,9 +23,9 @@ const BadgeCollectionPage = () => {
   const earnedBadgeCount = Object.keys(earnedBadges).length;
   const completionRate = ((earnedBadgeCount / totalBadges) * 100).toFixed(1);
 
-  const canonicalUrl = `https://beihaili.github.io/Get-Started-with-Web3/${lang}/badges`;
+  const canonicalUrl = buildSiteUrl(`/${lang}/badges`);
   const altLang = lang === 'en' ? 'zh' : 'en';
-  const alternateUrl = `https://beihaili.github.io/Get-Started-with-Web3/${altLang}/badges`;
+  const alternateUrl = buildSiteUrl(`/${altLang}/badges`);
 
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-slate-950">

--- a/src/pages/ContributorsPage.jsx
+++ b/src/pages/ContributorsPage.jsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { ArrowLeft, ExternalLink, GitPullRequest, Share2, Users } from 'lucide-react';
 import SeoHead from '../components/SeoHead';
 import LanguageSwitcher from '../components/LanguageSwitcher';
+import { buildSiteUrl } from '../config/siteConfig';
 
 const CACHE_KEY = 'gh_contributors_cache';
 const API_URL = 'https://api.github.com/repos/beihaili/Get-Started-with-Web3/contributors';
@@ -65,10 +66,9 @@ const ContributorsPage = () => {
     };
   }, []);
 
-  const siteUrl = 'https://beihaili.github.io/Get-Started-with-Web3/';
-  const canonicalUrl = `${siteUrl}${lang}/contributors`;
+  const canonicalUrl = buildSiteUrl(`/${lang}/contributors`);
   const altLang = lang === 'en' ? 'zh' : 'en';
-  const alternateUrl = `${siteUrl}${altLang}/contributors`;
+  const alternateUrl = buildSiteUrl(`/${altLang}/contributors`);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950">

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -11,6 +11,7 @@ import MobileNav from '../components/MobileNav';
 import SeoHead from '../components/SeoHead';
 import ProgressExport from '../components/ProgressExport';
 import ProgressImport from '../components/ProgressImport';
+import { buildSiteUrl } from '../config/siteConfig';
 
 /**
  * 仪表板页面
@@ -24,9 +25,9 @@ const DashboardPage = () => {
 
   const progressCount = Object.keys(progress).length;
 
-  const canonicalUrl = `https://beihaili.github.io/Get-Started-with-Web3/${lang}/dashboard`;
+  const canonicalUrl = buildSiteUrl(`/${lang}/dashboard`);
   const altLang = lang === 'en' ? 'zh' : 'en';
-  const alternateUrl = `https://beihaili.github.io/Get-Started-with-Web3/${altLang}/dashboard`;
+  const alternateUrl = buildSiteUrl(`/${altLang}/dashboard`);
 
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-slate-950">

--- a/src/pages/GlossaryPage.jsx
+++ b/src/pages/GlossaryPage.jsx
@@ -6,6 +6,7 @@ import LanguageSwitcher from '../components/LanguageSwitcher';
 import ThemeToggle from '../components/ThemeToggle';
 import SeoHead from '../components/SeoHead';
 import { GLOSSARY_DATA, GLOSSARY_CATEGORIES } from '../config/glossaryData';
+import { buildSiteUrl } from '../config/siteConfig';
 
 /**
  * Category color mapping for pill buttons and term tags.
@@ -45,10 +46,9 @@ const GlossaryPage = () => {
     });
   }, [searchQuery, activeCategory]);
 
-  const siteUrl = 'https://beihaili.github.io/Get-Started-with-Web3/';
-  const canonicalUrl = `${siteUrl}${lang}/glossary`;
+  const canonicalUrl = buildSiteUrl(`/${lang}/glossary`);
   const altLang = lang === 'en' ? 'zh' : 'en';
-  const alternateUrl = `${siteUrl}${altLang}/glossary`;
+  const alternateUrl = buildSiteUrl(`/${altLang}/glossary`);
 
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-slate-950">

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -22,6 +22,7 @@ import DonationSection from '../components/DonationSection';
 import SponsorSection from '../components/SponsorSection';
 import LanguageSwitcher from '../components/LanguageSwitcher';
 import SeoHead from '../components/SeoHead';
+import { APP_BASE_PATH, SITE_BASE_URL, buildSiteUrl, joinBasePath } from '../config/siteConfig';
 
 /**
  * 着陆页（首页）
@@ -33,10 +34,12 @@ const LandingPage = () => {
   const totalLessons = COURSE_DATA.reduce((sum, m) => sum + m.lessons.length, 0);
   const completedCount = Object.keys(progress).length;
 
-  const siteUrl = 'https://beihaili.github.io/Get-Started-with-Web3/';
-  const canonicalUrl = `${siteUrl}${lang}`;
+  const siteUrl = `${SITE_BASE_URL}/`;
+  const canonicalUrl = buildSiteUrl(`/${lang}`);
   const altLang = lang === 'en' ? 'zh' : 'en';
-  const alternateUrl = `${siteUrl}${altLang}`;
+  const alternateUrl = buildSiteUrl(`/${altLang}`);
+  const llmsTxtUrl = joinBasePath(APP_BASE_PATH, '/llms.txt');
+  const aiManifestUrl = joinBasePath(APP_BASE_PATH, '/ai/manifest.json');
 
   useEffect(() => {
     let script = document.querySelector('script[data-platform-ld]');
@@ -57,7 +60,7 @@ const LandingPage = () => {
         url: 'https://github.com/beihaili/Get-Started-with-Web3',
       },
     });
-  }, []);
+  }, [siteUrl]);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 relative overflow-hidden">
@@ -214,14 +217,14 @@ const LandingPage = () => {
                 <p className="text-slate-500 dark:text-slate-400 mb-5">{t('landing.agentDesc')}</p>
                 <div className="grid sm:grid-cols-3 gap-3">
                   <a
-                    href="/Get-Started-with-Web3/llms.txt"
+                    href={llmsTxtUrl}
                     className="flex items-center gap-2 px-4 py-3 rounded-lg bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 text-sm text-slate-700 dark:text-slate-200 hover:border-cyan-500/40 transition-colors"
                   >
                     <BookOpen className="w-4 h-4 text-cyan-400" />
                     llms.txt
                   </a>
                   <a
-                    href="/Get-Started-with-Web3/ai/manifest.json"
+                    href={aiManifestUrl}
                     className="flex items-center gap-2 px-4 py-3 rounded-lg bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 text-sm text-slate-700 dark:text-slate-200 hover:border-purple-500/40 transition-colors"
                   >
                     <FileJson className="w-4 h-4 text-purple-400" />

--- a/src/pages/ReaderPage.jsx
+++ b/src/pages/ReaderPage.jsx
@@ -19,6 +19,7 @@ import ContentSkeleton from '../components/ContentSkeleton';
 import ScrollToTop from '../components/ScrollToTop';
 import { estimateReadingTime } from '../utils/readingTime';
 import { useSwipe } from '../hooks/useSwipe';
+import { buildSiteUrl } from '../config/siteConfig';
 
 function getFocusableElements(container) {
   if (!container) {
@@ -192,10 +193,10 @@ const ReaderPage = () => {
   const pageDescription = currentLesson
     ? `${currentLesson.title} - ${currentModule?.title} ${t('reader.pageDescSuffix')}`
     : 'Web3 Starter';
-  const canonicalUrl = `https://beihaili.github.io/Get-Started-with-Web3/${lang}/learn/${moduleId}/${lessonId}`;
+  const canonicalUrl = buildSiteUrl(`/${lang}/learn/${moduleId}/${lessonId}`);
 
   const altLang = lang === 'en' ? 'zh' : 'en';
-  const alternateUrl = `https://beihaili.github.io/Get-Started-with-Web3/${altLang}/learn/${moduleId}/${lessonId}`;
+  const alternateUrl = buildSiteUrl(`/${altLang}/learn/${moduleId}/${lessonId}`);
   const displayLoading = currentLesson ? loading : false;
   const displayError = currentLesson ? error : t('reader.courseNotFound');
 

--- a/src/pages/SupportPage.jsx
+++ b/src/pages/SupportPage.jsx
@@ -5,6 +5,7 @@ import { DONATION_LINKS, CRYPTO_WALLETS, SPONSORS, AFFILIATE_LINKS } from '../co
 import SeoHead from '../components/SeoHead';
 import LanguageSwitcher from '../components/LanguageSwitcher';
 import { useClipboard } from '../utils/useClipboard';
+import { buildSiteUrl } from '../config/siteConfig';
 
 /**
  * 支持页面 — 展示捐赠渠道、加密货币钱包地址和赞助商信息
@@ -14,10 +15,9 @@ const SupportPage = () => {
   const { t } = useTranslation();
   const { copied, copy } = useClipboard();
 
-  const siteUrl = 'https://beihaili.github.io/Get-Started-with-Web3/';
-  const canonicalUrl = `${siteUrl}${lang}/support`;
+  const canonicalUrl = buildSiteUrl(`/${lang}/support`);
   const altLang = lang === 'en' ? 'zh' : 'en';
-  const alternateUrl = `${siteUrl}${altLang}/support`;
+  const alternateUrl = buildSiteUrl(`/${altLang}/support`);
 
   // 判断是否有任何赞助商
   const hasSponsors =

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -8,6 +8,8 @@ import { useThemeStore } from '../store/useThemeStore';
 import LanguageProvider from '../i18n/LanguageProvider';
 import { getRouteI18nSections } from '../i18n/namespaceLoaders';
 import { useI18nSections } from '../i18n/useI18nSections';
+import RouteAnalytics from '../components/RouteAnalytics';
+import { APP_BASE_PATH } from '../config/siteConfig';
 
 // Lazy load pages for code splitting
 const LandingPage = lazy(() => import('../pages/LandingPage'));
@@ -74,6 +76,7 @@ const RootLayout = () => {
 
   return (
     <>
+      <RouteAnalytics />
       <Outlet />
       <SearchDialog />
     </>
@@ -103,6 +106,8 @@ const LegacyRedirect = ({ to }) => {
   if (params.lessonId) path = path.replace(':lessonId', params.lessonId);
   return <Navigate to={path} replace />;
 };
+
+const ROUTER_BASENAME = APP_BASE_PATH === '/' ? '/' : APP_BASE_PATH.replace(/\/$/, '');
 
 /**
  * 应用路由配置
@@ -214,7 +219,7 @@ export const router = createBrowserRouter(
     },
   ],
   {
-    basename: '/Get-Started-with-Web3',
+    basename: ROUTER_BASENAME,
   }
 );
 

--- a/src/store/useContentStore.js
+++ b/src/store/useContentStore.js
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { APP_BASE_PATH } from '../config/siteConfig';
 
 /**
  * 内容管理状态
@@ -37,7 +38,7 @@ export const useContentStore = create((set, get) => ({
   fetchError: null,
 
   // 基础路径配置
-  basePath: '/Get-Started-with-Web3/',
+  basePath: APP_BASE_PATH,
 
   // Actions - 导航
   setActiveModule: (moduleId) =>

--- a/src/utils/__tests__/analytics.test.js
+++ b/src/utils/__tests__/analytics.test.js
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildAnalyticsPagePayload, trackPageView } from '../analytics';
+
+describe('analytics utilities', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    document.title = 'Get Started with Web3';
+  });
+
+  it('builds GA page_view payloads with the deployed base path and canonical location', () => {
+    expect(
+      buildAnalyticsPagePayload(
+        { pathname: '/en/dashboard', search: '?utm_source=x', hash: '#progress' },
+        {
+          basePath: '/Get-Started-with-Web3/',
+          siteBaseUrl: 'https://beihaili.github.io/Get-Started-with-Web3',
+        }
+      )
+    ).toMatchObject({
+      page_path: '/Get-Started-with-Web3/en/dashboard?utm_source=x#progress',
+      page_location:
+        'https://beihaili.github.io/Get-Started-with-Web3/en/dashboard?utm_source=x#progress',
+      page_title: 'Get Started with Web3',
+    });
+  });
+
+  it('sends a page_view event when gtag is available', () => {
+    const gtag = vi.fn();
+    vi.stubGlobal('gtag', gtag);
+
+    const sent = trackPageView(
+      { pathname: '/zh/learn/module-1/1-1', search: '', hash: '' },
+      {
+        basePath: '/Get-Started-with-Web3/',
+        siteBaseUrl: 'https://beihaili.github.io/Get-Started-with-Web3',
+      }
+    );
+
+    expect(sent).toBe(true);
+    expect(gtag).toHaveBeenCalledWith(
+      'event',
+      'page_view',
+      expect.objectContaining({
+        page_path: '/Get-Started-with-Web3/zh/learn/module-1/1-1',
+        page_location: 'https://beihaili.github.io/Get-Started-with-Web3/zh/learn/module-1/1-1',
+      })
+    );
+  });
+
+  it('does not throw when analytics scripts are blocked or unavailable', () => {
+    vi.stubGlobal('gtag', undefined);
+
+    expect(trackPageView({ pathname: '/en', search: '', hash: '' })).toBe(false);
+  });
+});

--- a/src/utils/analytics.js
+++ b/src/utils/analytics.js
@@ -1,0 +1,42 @@
+import {
+  APP_BASE_PATH,
+  SITE_BASE_URL,
+  buildSiteUrl,
+  joinBasePath,
+  normalizeBasePath,
+  normalizeSiteBaseUrl,
+} from '../config/siteConfig';
+
+function buildRoutePath(location = {}) {
+  const pathname = location.pathname || '/';
+  const search = location.search || '';
+  const hash = location.hash || '';
+  return `${pathname}${search}${hash}`;
+}
+
+export function buildAnalyticsPagePayload(location, options = {}) {
+  const basePath = normalizeBasePath(options.basePath || APP_BASE_PATH);
+  const siteBaseUrl = normalizeSiteBaseUrl(options.siteBaseUrl || SITE_BASE_URL);
+  const routePath = buildRoutePath(location);
+  const pageLocation = buildSiteUrl(routePath, siteBaseUrl);
+  const pageUrl = new URL(pageLocation);
+  const pageTitle = typeof document === 'undefined' ? undefined : document.title;
+  const referrer = typeof document === 'undefined' ? undefined : document.referrer || undefined;
+
+  return {
+    page_path: joinBasePath(basePath, routePath),
+    page_location: pageLocation,
+    page_title: pageTitle,
+    page_referrer: referrer,
+    page_hostname: pageUrl.hostname,
+  };
+}
+
+export function trackPageView(location, options = {}) {
+  if (typeof window === 'undefined' || typeof window.gtag !== 'function') {
+    return false;
+  }
+
+  window.gtag('event', 'page_view', buildAnalyticsPagePayload(location, options));
+  return true;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,10 +1,14 @@
+/* global process */
+
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+
+const basePath = process.env.VITE_BASE_PATH || '/Get-Started-with-Web3/';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/Get-Started-with-Web3/', // 正确的GitHub仓库名
+  base: basePath, // 默认使用 GitHub Pages project path；自定义域名构建可设 VITE_BASE_PATH=/
   build: {
     // 避免CSP问题 - 不在生产环境使用eval
     sourcemap: false,


### PR DESCRIPTION
## Summary
- centralize public site URL and base-path handling for current GitHub Pages and future custom-domain builds
- add SPA route-level GA page_view tracking while disabling GA auto initial pageview
- make sitemap, robots, prerender, AI artifact URLs, public AI links, service worker, and share/canonical URLs follow the shared config
- update operating docs with analytics/domain-readiness status and new community PR queue snapshot

## Verification
- npx vitest run src/config/__tests__/siteConfig.test.js src/utils/__tests__/analytics.test.js src/components/__tests__/RouteAnalytics.test.jsx scripts/__tests__/ai-public-entrypoints.test.js scripts/__tests__/seo-route-coverage.test.js
- npm run lint
- npm test
- npm run ai:verify
- npm run build
- local preview browser smoke for /en -> /en/dashboard canonical + GA page_view routing
- SITE_BASE_URL=https://web3.bhbtc.xyz node --input-type=module dry-run for AI public URLs

## Notes
- This does not add public/CNAME or change DNS/GitHub Pages custom-domain settings. bhbtc.xyz activation still needs host/DNS confirmation.
