### PR TITLE
fix: avoid fork PR preview comment failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,7 @@ jobs:
           retention-days: 7
 
       - name: Comment PR with Preview Link 💬
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v9
         with:
           script: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@
 - `CONTRIBUTING.md` / `CONTRIBUTING.en.md`: 双语贡献指南，维护贡献路径、验证矩阵和内容质量标准。
 - `.github/ISSUE_TEMPLATE/`: Bug、feature、content/translation、growth/community 分流模板。
 - `.github/PULL_REQUEST_TEMPLATE.md`: PR 验证和内容安全检查清单。
-- `.github/workflows/deploy.yml`: PR 构建会上传 `dist` artifact，并用固定 marker 更新同一条 PR 评论，方便评审者从 Actions run 下载构建产物；合并到 `main` 后才部署 GitHub Pages。
+- `.github/workflows/deploy.yml`: PR 构建会上传 `dist` artifact；同仓库 PR 会用固定 marker 更新同一条 PR 评论，fork PR 因 `GITHUB_TOKEN` 写权限受限会跳过评论但不应让构建失败；合并到 `main` 后才部署 GitHub Pages。
 - `.github/dependabot.yml`: 每周检查 npm 依赖和每月检查 GitHub Actions；minor/patch 更新分组，major 更新单独处理；`@commitlint/cli` v21、`@commitlint/config-conventional` v21 和 `lint-staged` v17 当前被忽略，因为它们要求 Node 22，而项目 CI 仍使用 Node 20，需等计划内 Node 22 迁移后再解除。
 - GitHub Issue [#156](https://github.com/beihaili/Get-Started-with-Web3/issues/156): 已 pin 的公开 1000-star roadmap；维护 starter issue 队列、翻译、分发、AI-native 和赞助动作时同步参考。
 

--- a/docs/operations/2026-05-19-daily-report.md
+++ b/docs/operations/2026-05-19-daily-report.md
@@ -28,6 +28,7 @@
 - Dependency hygiene: `.github/dependabot.yml` now ignores Node 22-only major updates for `@commitlint/cli`, `@commitlint/config-conventional`, and `lint-staged` until the project intentionally migrates CI and local contributor docs from Node 20.
 - CI tooling: `actions/upload-artifact` is moving to v7 together with the workflow regression test that verifies PR build artifact comments, superseding Dependabot PR [#190](https://github.com/beihaili/Get-Started-with-Web3/pull/190).
 - Website observability/domain readiness: added centralized site URL/base-path config, SPA route-level GA `page_view` tracking, env-driven sitemap/robots/AI artifact URLs, and custom-domain-safe build knobs (`VITE_SITE_BASE_URL` / `SITE_BASE_URL`, `VITE_BASE_PATH`) without enabling CNAME or DNS changes yet.
+- Community CI triage: identified that fork PRs [#194](https://github.com/beihaili/Get-Started-with-Web3/pull/194) and [#195](https://github.com/beihaili/Get-Started-with-Web3/pull/195) built successfully but failed when the workflow tried to write a PR artifact comment without token permission; prepared a workflow guard so fork PRs still upload artifacts without failing the build.
 
 ## Deploy And Verification
 
@@ -39,7 +40,8 @@
 | AI index                 | Success | `npm run ai:index`, `npm run ai:publish`                                                      | 11 modules, 108 lesson entries, 57 glossary entries                                                           |
 | AI entrypoints           | Success | `npm run ai:verify`                                                                           | Source/public artifacts, MCP tools, `llms.txt`, and x402 metadata pass                                        |
 | Site analytics/domain    | Success | Targeted Vitest + local preview browser smoke                                                 | Custom-domain URL helpers, route-level pageview tracking, canonical updates, sitemap, and robots pass locally |
-| Test suite               | Success | `npm test`                                                                                    | 43 test files and 226 tests passed                                                                            |
+| Fork PR artifact comment | Local   | `npx vitest run scripts/__tests__/deploy-workflow.test.js`                                    | Regression test added for skipping PR comments on fork branches while keeping artifact uploads                |
+| Test suite               | Success | `npm test`                                                                                    | 43 test files and 227 tests passed                                                                            |
 | Lint                     | Success | `npm run lint`                                                                                | ESLint completed with zero reported errors                                                                    |
 | Production build         | Success | `npm run build`                                                                               | Vite build plus 131/131 prerendered routes passed, including `/en/learn/module-9/9-2`                         |
 | Formatting               | Success | `npx prettier --check ...`                                                                    | Changed Markdown files use Prettier style                                                                     |
@@ -67,7 +69,7 @@
 ## Blockers And Risks
 
 - Growth remains flat at 614 stars; the next growth move needs actual public distribution, not only internal content shipping.
-- Community PR queue reopened with 3 external PRs; #196 overlaps the remaining Layer 2 translation work and is currently marked DIRTY, so review and conflict triage are needed before merging.
+- Community PR queue reopened with 3 external PRs; #194/#195 need rerun after the fork-PR workflow guard lands, and #196 overlaps the remaining Layer 2 translation work and is currently marked DIRTY.
 - Dependabot queue is controlled, but Node 22 migration remains a technical stewardship item before accepting `@commitlint/cli` v21, `@commitlint/config-conventional` v21, or `lint-staged` v17.
 - Layer 2 English coverage improves, but three lessons still remain after this branch; broader DAO and non-core docs still need translation or classification.
 - Sponsor outreach remains drafted but unsent; actual external sending still needs a confirmed human channel or connector.

--- a/scripts/__tests__/deploy-workflow.test.js
+++ b/scripts/__tests__/deploy-workflow.test.js
@@ -21,4 +21,12 @@ describe('deploy workflow PR feedback', () => {
     expect(workflow).toContain('github.rest.issues.updateComment');
     expect(workflow).toContain('github.rest.issues.createComment');
   });
+
+  it('does not let fork PR preview comments fail otherwise successful builds', async () => {
+    const workflow = await readFile(path.join(projectRoot, '.github/workflows/deploy.yml'), 'utf8');
+
+    expect(workflow).toContain(
+      'github.event.pull_request.head.repo.full_name == github.repository'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- prevent the PR preview comment step from running on forked pull requests where `GITHUB_TOKEN` cannot write issue comments
- keep artifact uploads enabled for all PRs so maintainers can still download `dist` from the Actions run
- add a deploy workflow regression test and update ops/agent notes

## Root cause
Fork PRs #194 and #195 completed build + artifact upload, then failed when `actions/github-script` tried to create the PR artifact comment and GitHub returned `Resource not accessible by integration` (403).

## Verification
- npx vitest run scripts/__tests__/deploy-workflow.test.js
- npm run lint
- npm test
- npx prettier --check AGENTS.md docs/operations/2026-05-19-daily-report.md .github/workflows/deploy.yml scripts/__tests__/deploy-workflow.test.js
- git diff --check
