### PR TITLE
docs: add remaining L2 English translations

### DIFF
--- a/ai/content-index.json
+++ b/ai/content-index.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2026-05-09",
-  "generatedAt": "2026-05-19T07:20:59.655Z",
+  "generatedAt": "2026-05-19T10:57:56.815Z",
   "repository": {
     "name": "Get-Started-with-Web3",
     "owner": "beihaili",
@@ -753,7 +753,7 @@
           "labUrl": null,
           "availability": {
             "zh": true,
-            "en": false
+            "en": true
           },
           "siteUrls": {
             "zh": "https://beihaili.github.io/Get-Started-with-Web3/zh/learn/module-9/9-3",
@@ -767,7 +767,7 @@
           "labUrl": null,
           "availability": {
             "zh": true,
-            "en": false
+            "en": true
           },
           "siteUrls": {
             "zh": "https://beihaili.github.io/Get-Started-with-Web3/zh/learn/module-9/9-4",
@@ -781,7 +781,7 @@
           "labUrl": null,
           "availability": {
             "zh": true,
-            "en": false
+            "en": true
           },
           "siteUrls": {
             "zh": "https://beihaili.github.io/Get-Started-with-Web3/zh/learn/module-9/9-5",
@@ -15794,6 +15794,179 @@
       "characterCount": 11411
     },
     {
+      "id": "en/module-9/9-3",
+      "lang": "en",
+      "moduleId": "module-9",
+      "moduleTitle": "跨链与 Layer 2 深度解析",
+      "lessonId": "9-3",
+      "title": "主流 L2 生态对比",
+      "path": "L2CrossChain/03_L2Ecosystem",
+      "labUrl": null,
+      "sourcePath": "en/L2CrossChain/03_L2Ecosystem/README.md",
+      "citation": {
+        "file": "en/L2CrossChain/03_L2Ecosystem/README.md",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/en/L2CrossChain/03_L2Ecosystem/README.md",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/en/learn/module-9/9-3"
+      },
+      "excerpt": "The Major L2 Ecosystem Compared The Ethereum L2 ecosystem is thriving — each major Rollup has carved out its own niche in architecture, ecosystem building, and growth strategy. This lesson takes a deep look at five leading L2s: Arbitrum, Optimism, Base, zkSync, and StarkNet, so you can build a complete picture of the landscape. Follow me on Twitter: @bhbtc1337 Join the WeChat group: Form Link Articles are open source",
+      "headings": [
+        {
+          "level": 1,
+          "text": "The Major L2 Ecosystem Compared"
+        },
+        {
+          "level": 2,
+          "text": "Table of Contents"
+        },
+        {
+          "level": 2,
+          "text": "Arbitrum"
+        },
+        {
+          "level": 3,
+          "text": "Architecture"
+        },
+        {
+          "level": 3,
+          "text": "Arbitrum's Multi-Chain Strategy"
+        },
+        {
+          "level": 3,
+          "text": "Ecosystem Highlights"
+        },
+        {
+          "level": 3,
+          "text": "Governance: ARB Token"
+        },
+        {
+          "level": 2,
+          "text": "Optimism"
+        },
+        {
+          "level": 3,
+          "text": "Architecture"
+        },
+        {
+          "level": 3,
+          "text": "OP Stack and the Superchain Vision"
+        },
+        {
+          "level": 3,
+          "text": "OP Token and RetroPGF"
+        },
+        {
+          "level": 2,
+          "text": "Base"
+        },
+        {
+          "level": 3,
+          "text": "Coinbase's L2 Strategy"
+        },
+        {
+          "level": 3,
+          "text": "Base and OP Stack"
+        },
+        {
+          "level": 3,
+          "text": "Base Ecosystem"
+        },
+        {
+          "level": 2,
+          "text": "zkSync"
+        },
+        {
+          "level": 3,
+          "text": "The zkEVM Approach"
+        },
+        {
+          "level": 3,
+          "text": "Native Account Abstraction"
+        },
+        {
+          "level": 3,
+          "text": "ZK Token"
+        },
+        {
+          "level": 2,
+          "text": "StarkNet"
+        },
+        {
+          "level": 3,
+          "text": "StarkEx vs StarkNet"
+        },
+        {
+          "level": 3,
+          "text": "The Cairo Language"
+        },
+        {
+          "level": 3,
+          "text": "StarkNet's Technical Advantages"
+        },
+        {
+          "level": 3,
+          "text": "STRK Token"
+        },
+        {
+          "level": 2,
+          "text": "2026 Update: Blobs, PeerDAS, and L2 Risk Tiers"
+        },
+        {
+          "level": 3,
+          "text": "Blob Economics: Why L2s Became Cheap"
+        },
+        {
+          "level": 3,
+          "text": "PeerDAS: Scaling Without Sacrificing Node Accessibility"
+        },
+        {
+          "level": 3,
+          "text": "OP Superchain and the App-Chain Trend"
+        },
+        {
+          "level": 3,
+          "text": "Base: The Consumer L2"
+        },
+        {
+          "level": 3,
+          "text": "ZK Rollup: Strong Tech, but Ecosystem and Compatibility Still Challenges"
+        },
+        {
+          "level": 3,
+          "text": "Alt-DA, Validium, and the Difference from Rollup"
+        },
+        {
+          "level": 3,
+          "text": "A Risk Framework for Choosing an L2"
+        },
+        {
+          "level": 2,
+          "text": "Comprehensive L2 Comparison"
+        },
+        {
+          "level": 3,
+          "text": "Technical Comparison"
+        },
+        {
+          "level": 3,
+          "text": "Ecosystem Data (early 2025 reference)"
+        },
+        {
+          "level": 3,
+          "text": "How to Choose an L2?"
+        },
+        {
+          "level": 2,
+          "text": "Summary"
+        },
+        {
+          "level": 2,
+          "text": "Further Reading"
+        }
+      ],
+      "codeBlockCount": 7,
+      "characterCount": 22380
+    },
+    {
       "id": "zh/module-9/9-4",
       "lang": "zh",
       "moduleId": "module-9",
@@ -15945,6 +16118,159 @@
       ],
       "codeBlockCount": 15,
       "characterCount": 10015
+    },
+    {
+      "id": "en/module-9/9-4",
+      "lang": "en",
+      "moduleId": "module-9",
+      "moduleTitle": "跨链与 Layer 2 深度解析",
+      "lessonId": "9-4",
+      "title": "跨链桥与互操作性",
+      "path": "L2CrossChain/04_CrossChainBridges",
+      "labUrl": null,
+      "sourcePath": "en/L2CrossChain/04_CrossChainBridges/README.md",
+      "citation": {
+        "file": "en/L2CrossChain/04_CrossChainBridges/README.md",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/en/L2CrossChain/04_CrossChainBridges/README.md",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/en/learn/module-9/9-4"
+      },
+      "excerpt": "Cross Chain Bridges and Interoperability In a multi chain ecosystem, cross chain bridges are critical infrastructure connecting different blockchains. This lesson explains how bridges work, their trust models, and the leading protocols — and walks through major security incidents to build your risk awareness for cross chain operations. Follow me on Twitter: @bhbtc1337 Join the WeChat group: Form Link Articles are ope",
+      "headings": [
+        {
+          "level": 1,
+          "text": "Cross-Chain Bridges and Interoperability"
+        },
+        {
+          "level": 2,
+          "text": "Table of Contents"
+        },
+        {
+          "level": 2,
+          "text": "Why Cross-Chain Matters"
+        },
+        {
+          "level": 3,
+          "text": "The Multi-Chain Reality"
+        },
+        {
+          "level": 3,
+          "text": "The Core Challenge of Cross-Chain"
+        },
+        {
+          "level": 2,
+          "text": "How Cross-Chain Bridges Work"
+        },
+        {
+          "level": 3,
+          "text": "Mode 1: Lock-and-Mint"
+        },
+        {
+          "level": 3,
+          "text": "Mode 2: Burn-and-Mint"
+        },
+        {
+          "level": 3,
+          "text": "Mode 3: Atomic Swap"
+        },
+        {
+          "level": 2,
+          "text": "Bridge Trust Models"
+        },
+        {
+          "level": 3,
+          "text": "Tier 1: Native Bridge"
+        },
+        {
+          "level": 3,
+          "text": "Tier 2: Light-Client Verification Bridge"
+        },
+        {
+          "level": 3,
+          "text": "Tier 3: Optimistic Verification Bridge"
+        },
+        {
+          "level": 3,
+          "text": "Tier 4: External Validation Bridge"
+        },
+        {
+          "level": 3,
+          "text": "Trust Model Comparison"
+        },
+        {
+          "level": 2,
+          "text": "Leading Cross-Chain Protocols"
+        },
+        {
+          "level": 3,
+          "text": "LayerZero"
+        },
+        {
+          "level": 3,
+          "text": "Wormhole"
+        },
+        {
+          "level": 3,
+          "text": "Axelar"
+        },
+        {
+          "level": 3,
+          "text": "Connext (now Everclear)"
+        },
+        {
+          "level": 2,
+          "text": "Bridge Security Incidents"
+        },
+        {
+          "level": 3,
+          "text": "Ronin Bridge: $625M (March 2022)"
+        },
+        {
+          "level": 3,
+          "text": "Wormhole: $320M (February 2022)"
+        },
+        {
+          "level": 3,
+          "text": "Nomad: $190M (August 2022)"
+        },
+        {
+          "level": 3,
+          "text": "Attack Summary"
+        },
+        {
+          "level": 2,
+          "text": "Cross-Chain Security Best Practices"
+        },
+        {
+          "level": 3,
+          "text": "1. Prefer Official Bridges"
+        },
+        {
+          "level": 3,
+          "text": "2. Split Large Transfers"
+        },
+        {
+          "level": 3,
+          "text": "3. Check the Bridge's Security Status"
+        },
+        {
+          "level": 3,
+          "text": "4. Understand Wrapped Token Risk"
+        },
+        {
+          "level": 3,
+          "text": "5. Monitor Approvals and Interactions"
+        },
+        {
+          "level": 2,
+          "text": "Summary"
+        },
+        {
+          "level": 2,
+          "text": "Further Reading"
+        }
+      ],
+      "codeBlockCount": 15,
+      "characterCount": 19539
     },
     {
       "id": "zh/module-9/9-5",
@@ -16106,6 +16432,167 @@
       ],
       "codeBlockCount": 22,
       "characterCount": 8836
+    },
+    {
+      "id": "en/module-9/9-5",
+      "lang": "en",
+      "moduleId": "module-9",
+      "moduleTitle": "跨链与 Layer 2 深度解析",
+      "lessonId": "9-5",
+      "title": "L2 实操指南",
+      "path": "L2CrossChain/05_L2PracticalGuide",
+      "labUrl": null,
+      "sourcePath": "en/L2CrossChain/05_L2PracticalGuide/README.md",
+      "citation": {
+        "file": "en/L2CrossChain/05_L2PracticalGuide/README.md",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/en/L2CrossChain/05_L2PracticalGuide/README.md",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/en/learn/module-9/9-5"
+      },
+      "excerpt": "L2 Practical Guide Four lessons of theory — now it's time to act. This lesson walks you step by step through bridging assets to L2, configuring your wallet, using DeFi, and using real Gas fee data to help you make the best chain selection decisions. Follow me on Twitter: @bhbtc1337 Join the WeChat group: Form Link Articles are open sourced on GitHub: Get Started with Web3 Recommended exchange for buying BTC / ETH / U",
+      "headings": [
+        {
+          "level": 1,
+          "text": "L2 Practical Guide"
+        },
+        {
+          "level": 2,
+          "text": "Table of Contents"
+        },
+        {
+          "level": 2,
+          "text": "Bridging Assets from Ethereum to L2"
+        },
+        {
+          "level": 3,
+          "text": "Using the Arbitrum Official Bridge"
+        },
+        {
+          "level": 3,
+          "text": "Using Third-Party Bridges for Faster Withdrawals"
+        },
+        {
+          "level": 2,
+          "text": "Adding L2 Networks to MetaMask"
+        },
+        {
+          "level": 3,
+          "text": "Method 1: One-Click via ChainList"
+        },
+        {
+          "level": 3,
+          "text": "Method 2: Manual Configuration"
+        },
+        {
+          "level": 3,
+          "text": "Method 3: Auto-Add via DApp Prompt"
+        },
+        {
+          "level": 2,
+          "text": "Using DeFi on L2"
+        },
+        {
+          "level": 3,
+          "text": "Step 1: Ensure you have ETH for Gas"
+        },
+        {
+          "level": 3,
+          "text": "Step 2: Open Uniswap"
+        },
+        {
+          "level": 3,
+          "text": "Step 3: Execute the swap"
+        },
+        {
+          "level": 3,
+          "text": "Step 4: Verify the transaction"
+        },
+        {
+          "level": 3,
+          "text": "Other Common DeFi Operations"
+        },
+        {
+          "level": 2,
+          "text": "Gas Fee Comparison"
+        },
+        {
+          "level": 3,
+          "text": "ETH Transfer"
+        },
+        {
+          "level": 3,
+          "text": "Uniswap Swap"
+        },
+        {
+          "level": 3,
+          "text": "Key Takeaway"
+        },
+        {
+          "level": 2,
+          "text": "Chain Selection Strategy"
+        },
+        {
+          "level": 3,
+          "text": "Scenario 1: DeFi Trading (Large Amounts)"
+        },
+        {
+          "level": 3,
+          "text": "Scenario 2: DeFi Trading (Small Amounts / High Frequency)"
+        },
+        {
+          "level": 3,
+          "text": "Scenario 3: NFTs and Social Apps"
+        },
+        {
+          "level": 3,
+          "text": "Scenario 4: Developers Deploying a DApp"
+        },
+        {
+          "level": 3,
+          "text": "Scenario 5: Long-Term Asset Holding (Large Amounts)"
+        },
+        {
+          "level": 3,
+          "text": "Chain Selection Decision Tree"
+        },
+        {
+          "level": 2,
+          "text": "Common Pitfalls on L2"
+        },
+        {
+          "level": 3,
+          "text": "Pitfall 1: Wrapped Token Confusion"
+        },
+        {
+          "level": 3,
+          "text": "Pitfall 2: Running Out of Gas"
+        },
+        {
+          "level": 3,
+          "text": "Pitfall 3: Sequencer Single Point of Failure"
+        },
+        {
+          "level": 3,
+          "text": "Pitfall 4: Misjudging Cross-Chain Timing"
+        },
+        {
+          "level": 3,
+          "text": "Pitfall 5: Unstable RPC Nodes"
+        },
+        {
+          "level": 3,
+          "text": "Pitfall 6: Token Approval Management Across Chains"
+        },
+        {
+          "level": 2,
+          "text": "Summary"
+        },
+        {
+          "level": 2,
+          "text": "Further Reading"
+        }
+      ],
+      "codeBlockCount": 22,
+      "characterCount": 15951
     },
     {
       "id": "zh/module-10/10-1",

--- a/ai/llms.txt
+++ b/ai/llms.txt
@@ -4,7 +4,7 @@ This repository exposes bilingual Web3 learning content for AI agents.
 
 Source: https://github.com/beihaili/Get-Started-with-Web3
 Homepage: https://beihaili.github.io/Get-Started-with-Web3/
-Generated: 2026-05-19T07:20:59.655Z
+Generated: 2026-05-19T10:57:56.815Z
 
 ## Artifacts
 - Manifest: ai/manifest.json

--- a/ai/manifest.json
+++ b/ai/manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2026-05-09",
-  "generatedAt": "2026-05-19T07:20:59.655Z",
+  "generatedAt": "2026-05-19T10:57:56.815Z",
   "repository": {
     "name": "Get-Started-with-Web3",
     "owner": "beihaili",
@@ -14,7 +14,7 @@
   ],
   "counts": {
     "modules": 11,
-    "lessons": 108,
+    "lessons": 111,
     "glossaryEntries": 57,
     "tools": 8,
     "futurePaidTools": 2

--- a/docs/operations/2026-05-19-daily-report.md
+++ b/docs/operations/2026-05-19-daily-report.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-05-19
 **Owner:** beihai + Codex
-**Reporting window:** 2026-05-19 15:27 CST snapshot; GitHub timestamps are UTC unless noted.
+**Reporting window:** 2026-05-19 18:55 CST snapshot; GitHub timestamps are UTC unless noted.
 
 ## KPI Snapshot
 
@@ -12,51 +12,52 @@
 | Forks             |      58 |                  57 |       +1 | `gh repo view beihaili/Get-Started-with-Web3` |
 | Watchers          |       3 |                   3 |        0 | `gh repo view beihaili/Get-Started-with-Web3` |
 | Contributors      |      13 |                  13 |        0 | `gh api repos/.../contributors`               |
-| Open PRs          |       3 |                   0 |       +3 | `gh pr list --state open`                     |
+| Open PRs          |       1 |                   0 |       +1 | `gh pr list --state open`                     |
 | Open issues       |      12 |                  12 |        0 | `gh issue list --state open --limit 200`      |
 | Good first issues |      11 |                  11 |        0 | `gh issue list` label count                   |
 
 ## Completed
 
 - Content product: published the second English Layer 2 / cross-chain lesson translation via [#184](https://github.com/beihaili/Get-Started-with-Web3/pull/184), covering Rollup fundamentals, Optimistic Rollups, ZK Rollups, data availability, Validium, and Volition.
-- AI-native maintenance: regenerated `ai/` and `public/ai/` artifacts after the new English lesson and smart-account glossary merge; the AI-native index now contains 108 lesson entries, 57 glossary entries, and module `9-2` has English availability set to `true`.
-- Translation operations: reduced local translation coverage warnings from 16 to 15; the remaining Layer 2 gaps are `03_L2Ecosystem`, `04_CrossChainBridges`, and `05_L2PracticalGuide`.
+- AI-native maintenance: regenerated `ai/` and `public/ai/` artifacts after the new English lessons and smart-account glossary merge; the AI-native index now contains 111 lesson entries, 57 glossary entries, and module 9 lessons `9-2` to `9-5` have English availability set to `true` locally.
+- Translation operations: reduced local translation coverage warnings from 16 to 15 after lesson 9-2, then prepared the remaining Layer 2 English lessons `03_L2Ecosystem`, `04_CrossChainBridges`, and `05_L2PracticalGuide` from the unmerged portions of [#196](https://github.com/beihaili/Get-Started-with-Web3/pull/196), bringing the local warning count down to 12.
 - Community backlog: updated [#175](https://github.com/beihaili/Get-Started-with-Web3/issues/175#issuecomment-4483580706) so contributors can see that lesson 9-2 is complete and only lessons 9-3 to 9-5 remain in that issue.
 - Distribution planning: published `docs/strategy/2026-05-19-content-calendar.md`, defining an eight-week public content cadence and weekly theme-to-CTA mapping so shipped work consistently feeds stars/contributor growth.
 - Contributor loop: [#177](https://github.com/beihaili/Get-Started-with-Web3/pull/177) and [#178](https://github.com/beihaili/Get-Started-with-Web3/pull/178) merged, closing [#162](https://github.com/beihaili/Get-Started-with-Web3/issues/162) and [#158](https://github.com/beihaili/Get-Started-with-Web3/issues/158).
-- Community backlog: opened replacement growth starter issues [#186](https://github.com/beihaili/Get-Started-with-Web3/issues/186) and [#187](https://github.com/beihaili/Get-Started-with-Web3/issues/187), keeping the open good-first issue queue at 11; new community PRs [#194](https://github.com/beihaili/Get-Started-with-Web3/pull/194), [#195](https://github.com/beihaili/Get-Started-with-Web3/pull/195), and [#196](https://github.com/beihaili/Get-Started-with-Web3/pull/196) are pending review.
+- Community backlog: opened replacement growth starter issues [#186](https://github.com/beihaili/Get-Started-with-Web3/issues/186) and [#187](https://github.com/beihaili/Get-Started-with-Web3/issues/187), keeping the open good-first issue queue at 11.
+- Community PR handling: merged [#194](https://github.com/beihaili/Get-Started-with-Web3/pull/194) after the fork-PR workflow fix landed and closed [#195](https://github.com/beihaili/Get-Started-with-Web3/pull/195) because it became an empty duplicate of already-merged glossary terms; [#196](https://github.com/beihaili/Get-Started-with-Web3/pull/196) remains DIRTY and is being superseded by a maintainer branch that only extracts the still-needed L2 translations.
 - GitHub triage: Dependabot PRs [#179](https://github.com/beihaili/Get-Started-with-Web3/pull/179), [#180](https://github.com/beihaili/Get-Started-with-Web3/pull/180), [#182](https://github.com/beihaili/Get-Started-with-Web3/pull/182), and [#191](https://github.com/beihaili/Get-Started-with-Web3/pull/191) landed; Node 22-only PRs [#181](https://github.com/beihaili/Get-Started-with-Web3/pull/181), [#183](https://github.com/beihaili/Get-Started-with-Web3/pull/183), and [#192](https://github.com/beihaili/Get-Started-with-Web3/pull/192) were closed with migration notes.
 - Dependency hygiene: `.github/dependabot.yml` now ignores Node 22-only major updates for `@commitlint/cli`, `@commitlint/config-conventional`, and `lint-staged` until the project intentionally migrates CI and local contributor docs from Node 20.
 - CI tooling: `actions/upload-artifact` is moving to v7 together with the workflow regression test that verifies PR build artifact comments, superseding Dependabot PR [#190](https://github.com/beihaili/Get-Started-with-Web3/pull/190).
 - Website observability/domain readiness: added centralized site URL/base-path config, SPA route-level GA `page_view` tracking, env-driven sitemap/robots/AI artifact URLs, and custom-domain-safe build knobs (`VITE_SITE_BASE_URL` / `SITE_BASE_URL`, `VITE_BASE_PATH`) without enabling CNAME or DNS changes yet.
-- Community CI triage: identified that fork PRs [#194](https://github.com/beihaili/Get-Started-with-Web3/pull/194) and [#195](https://github.com/beihaili/Get-Started-with-Web3/pull/195) built successfully but failed when the workflow tried to write a PR artifact comment without token permission; prepared a workflow guard so fork PRs still upload artifacts without failing the build.
+- Community CI triage: fixed the fork-PR artifact-comment failure in [#198](https://github.com/beihaili/Get-Started-with-Web3/pull/198); fork PRs still upload build artifacts, but the workflow now skips same-PR comment writes when the contributor branch is from a fork.
 
 ## Deploy And Verification
 
 | Surface                  | Status  | Evidence                                                                                      | Notes                                                                                                         |
 | ------------------------ | ------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| Latest production deploy | Success | [Run 26072572474](https://github.com/beihaili/Get-Started-with-Web3/actions/runs/26072572474) | Latest main deploy completed successfully for head `94c1729`                                                  |
-| Public lesson route      | Success | `curl -L .../en/learn/module-9/9-2`                                                           | HTTP 200 and prerendered HTML contains `Rollup Principles Explained`                                          |
-| Translation coverage     | Success | `npm run translation:check`                                                                   | 15 missing-English warnings remain after adding lesson 9-2                                                    |
-| AI index                 | Success | `npm run ai:index`, `npm run ai:publish`                                                      | 11 modules, 108 lesson entries, 57 glossary entries                                                           |
+| Latest production deploy | Success | [Run 26092160478](https://github.com/beihaili/Get-Started-with-Web3/actions/runs/26092160478) | Latest main deploy completed successfully for head `a0489d8c`, after #194 merged                              |
+| Public lesson route      | Success | `curl -L .../en/learn/module-9/9-2`                                                           | HTTP 200 and prerendered HTML contains `Rollup Principles Explained`; lessons 9-3 to 9-5 are verified locally |
+| Translation coverage     | Success | `npm run translation:check`                                                                   | 12 missing-English warnings remain locally after preparing lessons 9-3 to 9-5                                 |
+| AI index                 | Success | `npm run ai:index`, `npm run ai:publish`                                                      | 11 modules, 111 lesson entries, 57 glossary entries                                                           |
 | AI entrypoints           | Success | `npm run ai:verify`                                                                           | Source/public artifacts, MCP tools, `llms.txt`, and x402 metadata pass                                        |
 | Site analytics/domain    | Success | Targeted Vitest + local preview browser smoke                                                 | Custom-domain URL helpers, route-level pageview tracking, canonical updates, sitemap, and robots pass locally |
-| Fork PR artifact comment | Local   | `npx vitest run scripts/__tests__/deploy-workflow.test.js`                                    | Regression test added for skipping PR comments on fork branches while keeping artifact uploads                |
+| Fork PR artifact comment | Success | [#198](https://github.com/beihaili/Get-Started-with-Web3/pull/198)                            | Regression test added for skipping PR comments on fork branches while keeping artifact uploads                |
 | Test suite               | Success | `npm test`                                                                                    | 43 test files and 227 tests passed                                                                            |
 | Lint                     | Success | `npm run lint`                                                                                | ESLint completed with zero reported errors                                                                    |
-| Production build         | Success | `npm run build`                                                                               | Vite build plus 131/131 prerendered routes passed, including `/en/learn/module-9/9-2`                         |
+| Production build         | Success | `npm run build`                                                                               | Vite build plus 131/131 prerendered routes passed, including `/en/learn/module-9/9-3` to `9-5`                |
 | Formatting               | Success | `npx prettier --check ...`                                                                    | Changed Markdown files use Prettier style                                                                     |
 | Whitespace               | Success | `git diff --check`                                                                            | No whitespace errors                                                                                          |
 
 ## External Distribution
 
-| Target                       | Status  | Evidence                                                                                                                                                                                                   | Next action                                                                  |
-| ---------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| GitHub contributor backlog   | Updated | [#175 update](https://github.com/beihaili/Get-Started-with-Web3/issues/175#issuecomment-4483580706)                                                                                                        | Remaining L2 translation work is now lessons 9-3 to 9-5                      |
-| GitHub PR queue              | Review  | [#194](https://github.com/beihaili/Get-Started-with-Web3/pull/194), [#195](https://github.com/beihaili/Get-Started-with-Web3/pull/195), [#196](https://github.com/beihaili/Get-Started-with-Web3/pull/196) | Review #194/#195 checks; #196 is currently DIRTY and needs conflict handling |
-| Twitter/X and Farcaster post | Ready   | `docs/strategy/2026-05-15-public-post-drafts.md`                                                                                                                                                           | Publish Draft 3 from beihai account                                          |
-| learnblockchain.cn/community | Ready   | `docs/strategy/2026-05-15-public-post-drafts.md`                                                                                                                                                           | Publish Chinese community post when convenient                               |
-| TensorBlock awesome MCP      | Waiting | [PR #544](https://github.com/TensorBlock/awesome-mcp-servers/pull/544)                                                                                                                                     | Avoid repeat pings until reviewer responds                                   |
+| Target                       | Status  | Evidence                                                                                            | Next action                                                                    |
+| ---------------------------- | ------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| GitHub contributor backlog   | Updated | [#175 update](https://github.com/beihaili/Get-Started-with-Web3/issues/175#issuecomment-4483580706) | Close #175 after the maintainer translation branch lands                       |
+| GitHub PR queue              | Review  | [#196](https://github.com/beihaili/Get-Started-with-Web3/pull/196)                                  | Supersede with a maintainer PR that preserves only the still-needed L2 lessons |
+| Twitter/X and Farcaster post | Ready   | `docs/strategy/2026-05-15-public-post-drafts.md`                                                    | Publish Draft 3 from beihai account                                            |
+| learnblockchain.cn/community | Ready   | `docs/strategy/2026-05-15-public-post-drafts.md`                                                    | Publish Chinese community post when convenient                                 |
+| TensorBlock awesome MCP      | Waiting | [PR #544](https://github.com/TensorBlock/awesome-mcp-servers/pull/544)                              | Avoid repeat pings until reviewer responds                                     |
 
 ## Sponsor And Revenue
 
@@ -70,29 +71,31 @@
 ## Blockers And Risks
 
 - Growth remains flat at 614 stars; the next growth move needs actual public distribution, not only internal content shipping.
-- Community PR queue reopened with 3 external PRs; #194/#195 need rerun after the fork-PR workflow guard lands, and #196 overlaps the remaining Layer 2 translation work and is currently marked DIRTY.
+- Community PR queue is down to one open PR; #196 overlaps already-merged quiz and lesson 9-2 work, so direct merge would reintroduce conflicts.
 - Dependabot queue is controlled, but Node 22 migration remains a technical stewardship item before accepting `@commitlint/cli` v21, `@commitlint/config-conventional` v21, or `lint-staged` v17.
-- Layer 2 English coverage improves, but three lessons still remain after this branch; broader DAO and non-core docs still need translation or classification.
+- Layer 2 English coverage is locally complete after extracting lessons 9-3 to 9-5 from #196, but broader DAO and non-core docs still need translation or classification.
 - Sponsor outreach remains drafted but unsent; actual external sending still needs a confirmed human channel or connector.
 - `bhbtc.xyz` activation is prepared in code but not enabled; exact host, DNS provider setup, and GitHub Pages custom-domain readiness need confirmation before adding `public/CNAME` or changing Pages settings.
 - Hosted payment, x402 enforcement, affiliate expansion, wallet flows, and payment-address changes still require explicit user confirmation.
 
 ## Next Operating Block
 
-1. Finish PR/deploy for analytics/domain-readiness, then confirm production still serves GitHub Pages paths correctly.
-2. Review community PRs #194, #195, and #196; handle #196 conflicts before deciding whether it closes #175.
-3. Publish the ready X/Farcaster and Chinese community posts so the new content work feeds the 1000-star growth loop.
+1. Finish the maintainer PR for the remaining Layer 2 English translations, then close #196 as superseded/integrated and update #175.
+2. Publish the ready X/Farcaster and Chinese community posts so the new content work feeds the 1000-star growth loop.
+3. Decide whether to start the Node 22 migration branch or keep focusing on content distribution this week.
 
 ## Evidence Links
 
 - Repository: https://github.com/beihaili/Get-Started-with-Web3
 - Production site: https://beihaili.github.io/Get-Started-with-Web3/
-- Latest recorded main deploy: https://github.com/beihaili/Get-Started-with-Web3/actions/runs/26072572474
+- Latest recorded main deploy: https://github.com/beihaili/Get-Started-with-Web3/actions/runs/26092160478
 - Remaining L2 translation starter issue: https://github.com/beihaili/Get-Started-with-Web3/issues/175
 - Remaining L2 translation issue update: https://github.com/beihaili/Get-Started-with-Web3/issues/175#issuecomment-4483580706
 - First L2 English translation PR: https://github.com/beihaili/Get-Started-with-Web3/pull/174
 - Second L2 English translation PR: https://github.com/beihaili/Get-Started-with-Web3/pull/184
 - Second L2 English translation: `en/L2CrossChain/02_RollupPrinciples/README.md`
+- Remaining L2 translation source PR: https://github.com/beihaili/Get-Started-with-Web3/pull/196
+- Remaining L2 English translations: `en/L2CrossChain/03_L2Ecosystem/README.md`, `en/L2CrossChain/04_CrossChainBridges/README.md`, `en/L2CrossChain/05_L2PracticalGuide/README.md`
 - Quiz contributor PR: https://github.com/beihaili/Get-Started-with-Web3/pull/177
 - Glossary contributor PR: https://github.com/beihaili/Get-Started-with-Web3/pull/178
 - Dependabot eslint-config-prettier PR: https://github.com/beihaili/Get-Started-with-Web3/pull/182
@@ -103,9 +106,10 @@
 - Closed Node 22-only commitlint config PR: https://github.com/beihaili/Get-Started-with-Web3/pull/192
 - Replacement starter issue: https://github.com/beihaili/Get-Started-with-Web3/issues/186
 - Replacement starter issue: https://github.com/beihaili/Get-Started-with-Web3/issues/187
-- Open community PR: https://github.com/beihaili/Get-Started-with-Web3/pull/194
-- Open community PR: https://github.com/beihaili/Get-Started-with-Web3/pull/195
+- Merged community PR: https://github.com/beihaili/Get-Started-with-Web3/pull/194
+- Closed duplicate community PR: https://github.com/beihaili/Get-Started-with-Web3/pull/195
 - Open community PR: https://github.com/beihaili/Get-Started-with-Web3/pull/196
+- Fork PR workflow fix PR: https://github.com/beihaili/Get-Started-with-Web3/pull/198
 - Analytics/domain-readiness branch: `codex/site-analytics-domain-readiness`
 - Site config: `src/config/siteConfig.js`
 - Route analytics: `src/components/RouteAnalytics.jsx`

--- a/docs/strategy/2026-05-14-execution-board.md
+++ b/docs/strategy/2026-05-14-execution-board.md
@@ -11,7 +11,7 @@
 | Technical health | Healthy               | Ship analytics/domain-readiness safely, keep verification green, and plan Node 22 migration separately |
 | GitHub growth    | Under-monetized       | Improve README conversion and launch distribution campaigns                                            |
 | SEO              | Partially implemented | Fix language metadata and route coverage                                                               |
-| English content  | Incomplete            | Close 15 missing translations or classify non-course docs                                              |
+| English content  | Incomplete            | Close the remaining 12 missing translations or classify non-course docs                                |
 | AI-native layer  | Strong MVP            | Productize story and prepare paid-tool landing                                                         |
 | Monetization     | Passive only          | Create sponsor kit and sponsor outreach drafts                                                         |
 | Community        | Converting            | Keep accepted contributor PRs moving into recognition and backlog refresh                              |
@@ -61,10 +61,11 @@ Update weekly.
 
 **Outcome:** The curriculum feels complete and current enough to recommend.
 
-- [ ] Finish or classify the 15 missing English translations.
+- [ ] Finish or classify the remaining 12 missing English translations.
 - [ ] Prioritize English proofreading for the highest-intent pages: README, Web3 Quick Start, Bitcoin, DeFi, L2, AI-native entry.
 - [x] Start Layer 2 English coverage with `en/L2CrossChain/01_WhyScaling/README.md`.
 - [x] Add second Layer 2 English translation with `en/L2CrossChain/02_RollupPrinciples/README.md`.
+- [x] Complete Layer 2 English coverage with `en/L2CrossChain/03_L2Ecosystem/README.md`, `en/L2CrossChain/04_CrossChainBridges/README.md`, and `en/L2CrossChain/05_L2PracticalGuide/README.md`.
 - [x] Create a content calendar with one public content theme per week (`docs/strategy/2026-05-19-content-calendar.md`).
 - [ ] Turn newly added content modules into changelog/release notes.
 - [ ] Add "Last updated" or freshness signals where valuable.
@@ -182,3 +183,5 @@ Daily report should include:
 | 2026-05-19 | Cleared Dependabot queue                                                                        | Merged Node-20-compatible [#182](https://github.com/beihaili/Get-Started-with-Web3/pull/182) after local `npm run lint` and `npm test`; closed Node-22-only [#181](https://github.com/beihaili/Get-Started-with-Web3/pull/181) and [#183](https://github.com/beihaili/Get-Started-with-Web3/pull/183); added Dependabot ignore rules for those major lines until a planned Node 22 migration                                                                                                                                         |
 | 2026-05-19 | Completed second Dependabot follow-up                                                           | Merged Node-20-compatible [#191](https://github.com/beihaili/Get-Started-with-Web3/pull/191), closed Node-22-only [#192](https://github.com/beihaili/Get-Started-with-Web3/pull/192), and superseded failing [#190](https://github.com/beihaili/Get-Started-with-Web3/pull/190) by updating `actions/upload-artifact` and the matching workflow test together                                                                                                                                                                        |
 | 2026-05-19 | Prepared website analytics and `bhbtc.xyz` readiness                                            | Added centralized site URL/base-path config, route-level GA pageview tracking, env-driven sitemap/robots/AI artifact URL generation, and documented that CNAME/DNS activation still needs confirmation before changing GitHub Pages custom domain settings                                                                                                                                                                                                                                                                           |
+| 2026-05-19 | Fixed fork PR artifact-comment failures and merged growth calendar                              | Merged [#198](https://github.com/beihaili/Get-Started-with-Web3/pull/198) so fork PRs no longer fail when they cannot write preview comments; reran and merged [#194](https://github.com/beihaili/Get-Started-with-Web3/pull/194), adding `docs/strategy/2026-05-19-content-calendar.md`; closed [#195](https://github.com/beihaili/Get-Started-with-Web3/pull/195) as an empty duplicate after main already contained the glossary terms                                                                                            |
+| 2026-05-19 | Prepared final Layer 2 English translation integration                                          | Extracted the still-needed lessons 9-3 to 9-5 from dirty PR [#196](https://github.com/beihaili/Get-Started-with-Web3/pull/196) without taking its already-merged quiz and lesson 9-2 changes; regenerated AI artifacts to 111 lesson entries and reduced translation warnings to 12                                                                                                                                                                                                                                                  |

--- a/en/L2CrossChain/03_L2Ecosystem/README.md
+++ b/en/L2CrossChain/03_L2Ecosystem/README.md
@@ -1,0 +1,467 @@
+# The Major L2 Ecosystem Compared
+
+![status](https://img.shields.io/badge/status-completed-success)
+![author](https://img.shields.io/badge/author-beihaili-blue)
+![date](https://img.shields.io/badge/date-2025--06-orange)
+![difficulty](https://img.shields.io/badge/difficulty-intermediate-yellow)
+
+> The Ethereum L2 ecosystem is thriving — each major Rollup has carved out its own niche in architecture, ecosystem building, and growth strategy. This lesson takes a deep look at five leading L2s: Arbitrum, Optimism, Base, zkSync, and StarkNet, so you can build a complete picture of the landscape.
+>
+> Follow me on Twitter: [@bhbtc1337](https://twitter.com/bhbtc1337)
+>
+> Join the WeChat group: [Form Link](https://forms.gle/QMBwL6LwZyQew1tX8)
+>
+> Articles are open-sourced on GitHub: [Get-Started-with-Web3](https://github.com/beihaili/Get-Started-with-Web3)
+>
+> Recommended exchange for buying BTC / ETH / USDT: [Binance](https://www.binance.com/en) [Registration Link](https://www.bsmkweb.cc/register?ref=39797374)
+
+## Table of Contents
+
+- [Arbitrum](#arbitrum)
+- [Optimism](#optimism)
+- [Base](#base)
+- [zkSync](#zksync)
+- [StarkNet](#starknet)
+- [2026 Update: Blobs, PeerDAS, and L2 Risk Tiers](#2026-update-blobs-peerdas-and-l2-risk-tiers)
+- [Comprehensive L2 Comparison](#comprehensive-l2-comparison)
+- [Summary](#summary)
+- [Further Reading](#further-reading)
+
+## Arbitrum
+
+### Architecture
+
+Arbitrum is developed by Offchain Labs and currently holds the highest TVL of any Ethereum L2. It uses Optimistic Rollup technology.
+
+**Core technical stack:**
+
+- **ArbOS**: Arbitrum's operating system layer, running on L2. Manages transaction execution, Gas metering, and cross-chain communication.
+- **Nitro upgrade (August 2022)**: rewrote the core execution engine in Go, directly compiling the core of Geth (the Ethereum client).
+
+```text
+Nitro Architecture:
+
+User transaction → Sequencer
+                       │
+                       ▼
+              Geth execution engine (modified)
+                       │
+                       ▼
+             WASM state transition function
+                       │
+                       ▼
+  Fraud proof: re-executes disputed steps on L1 using WASM
+```
+
+**What Nitro improved:**
+
+- Transaction fees reduced by **5–10x**
+- EVM compatibility elevated from "EVM-compatible" to "near-equivalent"
+- Fraud proofs use WASM — more efficient and more secure
+
+### Arbitrum's Multi-Chain Strategy
+
+Arbitrum is not just a single chain; it has evolved into a full ecosystem:
+
+| Chain          | Type                        | Role                 | Characteristics                       |
+| -------------- | --------------------------- | -------------------- | ------------------------------------- |
+| Arbitrum One   | Optimistic Rollup           | General DeFi / dApps | Highest TVL, richest ecosystem        |
+| Arbitrum Nova  | AnyTrust (Validium variant) | Gaming and social    | Ultra-low fees, data managed by a DAC |
+| Arbitrum Orbit | L3 framework                | Custom app-chains    | Lets projects deploy their own L3     |
+
+### Ecosystem Highlights
+
+Arbitrum's DeFi ecosystem is the most vibrant of any L2:
+
+- **GMX**: a decentralized perpetuals exchange and the first L2-native DeFi protocol to achieve large-scale success. Supports up to 50x leverage on BTC, ETH, and other assets, renowned for minimal slippage.
+- **Camelot**: Arbitrum-native DEX with a dual-AMM model (volatile pool + stable pool), supporting custom fee tiers and NFT staking.
+- **Pendle**: yield tokenization protocol that lets users trade future yield. Saw massive success on Arbitrum.
+- **Radiant Capital**: cross-chain lending protocol that uses LayerZero for cross-chain liquidity.
+
+**On-chain data (early 2025 reference):**
+
+- Daily transactions: ~1–2 million
+- Unique addresses: over 20 million
+- DeFi protocols: 500+
+
+### Governance: ARB Token
+
+ARB is Arbitrum's governance token (airdropped March 2023). Holders vote in the Arbitrum DAO, which manages a multi-billion-dollar treasury used for ecosystem development and technical upgrades.
+
+## Optimism
+
+### Architecture
+
+Optimism is developed by OP Labs. It also uses Optimistic Rollup, but differs from Arbitrum in important technical details.
+
+**Bedrock upgrade (June 2023)** — Optimism's major technical overhaul:
+
+```text
+Bedrock Architecture:
+
+Execution Layer:     Modified Geth (op-geth)
+                          │
+Derivation Layer:    op-node (derives L2 state from L1)
+                          │
+Batch Submission:    Batcher (batches L2 data to L1)
+                          │
+Fault Proof:         Dispute resolution (cannon + op-program)
+```
+
+Bedrock's core design philosophy is **Minimal Diff** — reuse as much of the Ethereum client code as possible, and only modify what is necessary. This means:
+
+- Any Ethereum EIP upgrade can be integrated quickly.
+- The security audit surface is smaller.
+- Developer experience is nearly identical to Ethereum.
+
+### OP Stack and the Superchain Vision
+
+OP Stack is Optimism's most strategically significant innovation — a **modular, open-source L2 tech stack**.
+
+```text
+OP Stack Modular Architecture:
+
+┌─────────────────────────────────┐
+│       Application Layer (DApps)  │
+├─────────────────────────────────┤
+│       Execution Layer (op-geth)  │
+├─────────────────────────────────┤
+│      Derivation Layer (op-node)  │
+├─────────────────────────────────┤
+│     Settlement Layer (L1 contracts)  │
+├─────────────────────────────────┤
+│  Data Availability Layer (L1 Blob / Alt-DA) │
+└─────────────────────────────────┘
+```
+
+The **Superchain vision** is for all OP Stack-based L2s to form an **interconnected network of chains**:
+
+- Shared security (all anchored to Ethereum L1)
+- Native cross-chain messaging
+- Shared upgrades and maintenance
+- A positive-sum network effect flywheel
+
+More than 30 chains have already deployed on OP Stack, including Base, Zora, Mode, and Worldchain.
+
+### OP Token and RetroPGF
+
+Optimism's governance and incentive model is distinctive:
+
+- **OP token**: governance token used to vote in the Token House.
+- **Citizens' House**: a second governance body composed of soulbound-token holders.
+- **RetroPGF (Retroactive Public Goods Funding)**: contribute first, get rewarded later — not upfront grants.
+
+RetroPGF's guiding idea: "If you create something valuable for the ecosystem, the community will eventually reward you." This mechanism encourages long-termism and public goods development.
+
+## Base
+
+### Coinbase's L2 Strategy
+
+Base is an L2 built by Coinbase (the largest compliant U.S. exchange, a publicly listed company) on top of OP Stack. It launched in August 2023 and quickly became one of the top L2s.
+
+**Why did Coinbase build an L2?**
+
+```text
+Coinbase's Web3 strategy:
+
+Old path:  User → Coinbase App → centralized trading
+  Problem: user assets are custodied by Coinbase — not real Web3
+
+New path:  User → Coinbase Wallet → Base L2 → on-chain DeFi
+  Benefit: users control their assets, with low fees and a great experience
+```
+
+**Base's unique advantages:**
+
+1. **Coinbase user funnel**: Coinbase has over 100 million registered users who can be guided onto Base at low cost.
+2. **Fiat on-ramp**: Coinbase's compliant fiat channels let users buy assets on Base directly.
+3. **Brand trust**: as a public company, Coinbase's backing gives Base mainstream credibility.
+4. **Developer integration**: deep integration with Coinbase developer tools.
+
+### Base and OP Stack
+
+Base is one of the Superchain's core members:
+
+- Base contributes a portion of its sequencer revenue to the Optimism Collective.
+- In return, Base benefits from continuous OP Stack upgrades and security guarantees.
+- A win-win: Base gets the technology, Optimism gets the ecosystem and revenue.
+
+### Base Ecosystem
+
+Base is known for social and consumer-facing applications:
+
+- **Friend.tech**: social token trading platform that triggered a wave of attention in 2023.
+- **Farcaster ecosystem**: decentralized social protocol, with many apps deployed on Base.
+- **Aerodrome**: Base's largest DEX, forked from Velodrome (Optimism's top DEX).
+- **mint.fun / Zora ecosystem**: NFT minting and creator economy.
+
+**Base has no native token** — Coinbase has explicitly stated that Base will not have a native token. This means Base incentives come from the protocol level, not token speculation.
+
+## zkSync
+
+### The zkEVM Approach
+
+zkSync is developed by Matter Labs and is one of the most closely watched ZK Rollups. zkSync Era (mainnet launched March 2023) is its flagship product.
+
+**zkSync Era's technical characteristics:**
+
+```text
+Compilation pipeline:
+
+Solidity / Vyper source code
+       │
+       ▼
+  Solc / Vyper compiler
+       │
+       ▼
+    Yul (intermediate representation)
+       │
+       ▼
+  zkSync compiler (LLVM-based)
+       │
+       ▼
+  zkEVM bytecode
+```
+
+This compilation path makes zkSync a **Type 4 zkEVM** — high-level language compatible, but with different bytecode. Most Solidity code deploys directly, but some low-level operations (inline assembly, certain opcodes) may need adjustment.
+
+### Native Account Abstraction
+
+One of zkSync's major innovations is **protocol-level native account abstraction**:
+
+On Ethereum, there are two account types:
+
+- **EOA (Externally Owned Account)**: controlled by a private key — the standard wallet.
+- **Contract account**: controlled by code.
+
+Ethereum's ERC-4337 implements account abstraction at the application layer. zkSync does it at the protocol layer — **every account is a smart contract account**.
+
+This enables:
+
+- **Gas sponsorship**: projects can pay Gas fees on behalf of users (Paymaster mechanism).
+- **Social recovery**: lose your private key, recover your account via trusted contacts.
+- **Batched transactions**: sign once, execute multiple transactions (e.g., approve + swap together).
+- **Arbitrary signature schemes**: not limited to ECDSA — use Passkeys, face recognition, or any other scheme.
+
+### ZK Token
+
+The ZK token was airdropped in June 2024, but the airdrop generated controversy due to allegations of unfair distribution — a large number of Sybil-attack addresses received tokens. It became a cautionary tale for L2 airdrop strategy.
+
+## StarkNet
+
+### StarkEx vs StarkNet
+
+StarkWare has developed two products that are easy to confuse:
+
+| Property        | StarkEx                            | StarkNet                  |
+| --------------- | ---------------------------------- | ------------------------- |
+| Type            | App-specific Rollup                | General-purpose Rollup    |
+| Clients         | dYdX v3, Immutable X, Sorare       | Any developer             |
+| Data mode       | ZK Rollup or Validium (selectable) | ZK Rollup                 |
+| Smart contracts | No custom contracts                | Cairo contracts supported |
+| Launch          | 2020                               | 2022 (Alpha)              |
+
+StarkEx has processed over **$500 billion** in cumulative volume and hundreds of millions of transactions, proving the reliability of the STARK proof system.
+
+### The Cairo Language
+
+StarkNet's defining characteristic — and its most debated — is the use of its own programming language, **Cairo**, rather than Solidity.
+
+```cairo
+// Cairo example: a simple counter contract
+#[starknet::contract]
+mod Counter {
+    #[storage]
+    struct Storage {
+        count: u128,
+    }
+
+    #[external(v0)]
+    fn increment(ref self: ContractState) {
+        let current = self.count.read();
+        self.count.write(current + 1);
+    }
+
+    #[external(v0)]
+    fn get_count(self: @ContractState) -> u128 {
+        self.count.read()
+    }
+}
+```
+
+**Why Cairo instead of Solidity?**
+
+Cairo is designed specifically for the STARK proof system:
+
+- Every computation step can be efficiently proven.
+- Compiles to Sierra (Safe Intermediate Representation), then to CASM (Cairo Assembly).
+- Proof generation is several times faster than Solidity-transpiled approaches.
+
+**Drawback**: developers must learn a new language. DeFi protocols cannot be ported directly from Ethereum, which has slowed ecosystem growth.
+
+### StarkNet's Technical Advantages
+
+1. **STARK proofs**: no trusted setup required, quantum-resistant, transparent.
+2. **Recursive proofs**: one proof can verify another, dramatically reducing L1 verification costs.
+3. **SHARP (Shared Prover)**: multiple applications share a prover, amortizing proving costs.
+4. **Volition mode** (planned): users can choose whether their data is stored on L1 or off-chain.
+
+### STRK Token
+
+The STRK token launched in February 2024 and is used for Gas fees and governance. StarkNet Gas can be paid in either ETH or STRK — a relatively distinctive design.
+
+## 2026 Update: Blobs, PeerDAS, and L2 Risk Tiers
+
+The introduction of Blobs in the 2024 Dencun upgrade fundamentally changed the L2 cost structure. Pectra activated on Ethereum mainnet in May 2025 and doubled Blob throughput by raising the target from 3 to 6 Blobs per block and the maximum from 6 to 9. Fusaka followed in December 2025 and introduced PeerDAS, making further Blob scaling more sustainable through data availability sampling. Understanding L2s in 2026 means looking beyond TVL and fees — you also need to examine data availability, sequencer design, proof systems, and upgrade permissions.
+
+### Blob Economics: Why L2s Became Cheap
+
+Rollups need to publish transaction data to Ethereum so anyone can reconstruct the L2 state. Previously, much of this data lived in expensive `calldata`. EIP-4844's Blobs gave Rollups a dedicated data channel.
+
+```text
+L2 transaction fee
+  = L2 execution cost
+  + L1 data publication cost
+  + sequencer operations and margin
+  + congestion premium
+```
+
+Blobs reduce the "L1 data publication cost" component. With Pectra raising the target Blob capacity, L2s are less likely to see fee spikes from data space shortages under normal conditions. But Blobs are still a market resource — if multiple Rollups congest simultaneously, fees will rise.
+
+### PeerDAS: Scaling Without Sacrificing Node Accessibility
+
+Fusaka's PeerDAS addresses the problem that "more Blobs = heavier burden on full nodes." It allows nodes to participate in validation via data availability sampling — no single node needs to download all Blob data.
+
+What this means for L2:
+
+- Blob throughput can continue increasing.
+- Ordinary node bandwidth and hardware requirements won't scale linearly.
+- Low L2 fees have a better chance of being sustained long-term.
+- Rollup scaling depends more on Ethereum's DA capacity and less on centralized data layers.
+
+### OP Superchain and the App-Chain Trend
+
+OP Stack is no longer just Optimism mainnet — it is a reusable Rollup technology stack. Base, Zora, Mode, and Worldchain all follow this path.
+
+The core Superchain idea:
+
+- Multiple chains share OP Stack.
+- Upgrades, governance, and infrastructure are unified where possible.
+- Cross-chain messaging and asset movement become smoother over time.
+- Apps can choose to become their own dedicated chain rather than competing on a shared general-purpose L2.
+
+This creates a new question for users: not "Ethereum vs some L2," but "how do I safely operate across a set of chains sharing the same tech stack?"
+
+### Base: The Consumer L2
+
+Base's strength is not technical innovation — it's distribution:
+
+- Coinbase's user funnel provides fiat on-ramps and mainstream user access.
+- OP Stack gives it the full Superchain ecosystem.
+- Farcaster, social apps, creator economy, meme tokens, and micropayments are all active.
+- No native token removes the "interact just for the airdrop" narrative.
+
+Two key questions to track with Base:
+
+1. How it converts centralized-exchange users into self-custodial on-chain users.
+2. How it progressively decentralizes its sequencer, governance, data publication, and revenue model.
+
+### ZK Rollup: Strong Tech, but Ecosystem and Compatibility Still Challenges
+
+zkSync, StarkNet, Scroll, and Polygon zkEVM all belong to the ZK path, but they differ significantly in developer experience, EVM compatibility, proving costs, and ecosystem strategy.
+
+ZK Rollup advantages:
+
+- Validity proofs provide faster state correctness guarantees.
+- Withdrawal wait times can theoretically be shorter than Optimistic Rollup.
+- Well-suited for complex computation, privacy, gaming, and high-frequency applications over the long term.
+
+Challenges:
+
+- Proof systems are complex — hard to audit and implement.
+- Developer tooling and EVM compatibility need sustained refinement.
+- Cold-starting an ecosystem is harder than with the OP Stack path.
+- Upgrade keys and centralized provers remain phase-specific risks.
+
+### Alt-DA, Validium, and the Difference from Rollup
+
+Many low-fee chains use data availability solutions outside Ethereum — Celestia, EigenDA, Avail, or custom DACs. These can dramatically reduce fees, but the security assumptions differ.
+
+| Type                     | Where data lives            | Advantage                      | Risk                                      |
+| ------------------------ | --------------------------- | ------------------------------ | ----------------------------------------- |
+| Rollup                   | Ethereum L1 Blob / calldata | Inherits Ethereum DA security  | Higher cost                               |
+| Validium                 | Off-chain DA or committee   | Lower fees, higher throughput  | Harder user exit if data unavailable      |
+| Optimium / Alt-DA Rollup | Third-party DA layer        | Cost and scalability trade-off | Depends on additional DA network security |
+
+Don't just look at "low fees." Ask: if the operator acts maliciously or the DA layer goes down, can users exit independently?
+
+### A Risk Framework for Choosing an L2
+
+When using or researching an L2, check these seven questions:
+
+1. **Data availability**: is transaction data published to Ethereum, a third-party DA layer, or a committee?
+2. **Proof system**: is the fraud proof or validity proof actually live in production?
+3. **Sequencer**: is there a single sequencer? Is there a decentralization roadmap?
+4. **Exit path**: can users force-exit to L1?
+5. **Upgrade permissions**: are contracts upgradeable? What is the multisig or governance timelock?
+6. **Bridge security**: what risks does the official bridge carry vs. third-party bridges?
+7. **Ecosystem quality**: is TVL driven by real application demand, or short-term incentive farming?
+
+This framework matters more than "which L2 is cheapest."
+
+## Comprehensive L2 Comparison
+
+### Technical Comparison
+
+| Dimension           | Arbitrum          | Optimism          | Base              | zkSync Era      | StarkNet     |
+| ------------------- | ----------------- | ----------------- | ----------------- | --------------- | ------------ |
+| Type                | Optimistic Rollup | Optimistic Rollup | Optimistic Rollup | ZK Rollup       | ZK Rollup    |
+| EVM compatibility   | High (Nitro)      | High (Bedrock)    | High (OP Stack)   | Medium (Type 4) | None (Cairo) |
+| Account abstraction | ERC-4337          | ERC-4337          | ERC-4337          | Native          | Native       |
+| Withdrawal time     | 7 days            | 7 days            | 7 days            | ~1 hour         | ~hours       |
+| Proof system        | Fraud proofs      | Fraud proofs      | Fraud proofs      | ZK-SNARK        | ZK-STARK     |
+
+### Ecosystem Data (early 2025 reference)
+
+| Metric                 | Arbitrum | Optimism  | Base         | zkSync Era | StarkNet       |
+| ---------------------- | -------- | --------- | ------------ | ---------- | -------------- |
+| TVL order of magnitude | $10B+    | $5B+      | $5B+         | $500M+     | $200M+         |
+| Daily transactions     | 1–2M     | 0.5–1M    | 2–4M         | 0.1–0.5M   | 0.1–0.3M       |
+| DeFi protocols         | 500+     | 200+      | 300+         | 100+       | 50+            |
+| Native token           | ARB      | OP        | None         | ZK         | STRK           |
+| Governance model       | DAO      | Bicameral | Coinbase-led | DAO        | Foundation-led |
+
+> Note: these figures are reference values; actual data fluctuates with the market. See [L2Beat](https://l2beat.com/) for the latest.
+
+### How to Choose an L2?
+
+For different user types:
+
+- **Heavy DeFi users**: Arbitrum (richest DeFi ecosystem)
+- **Fee-conscious users**: Base or Arbitrum (extremely low cost after EIP-4844)
+- **Mainstream / new users**: Base (Coinbase on-ramp, best UX)
+- **Developers (fast deployment)**: Arbitrum / Base / Optimism (full EVM compatibility)
+- **Developers (cutting-edge tech)**: zkSync / StarkNet (native ZK capabilities)
+- **Gaming projects**: Arbitrum Nova / StarkNet (optimized for high-frequency, low-value transactions)
+
+## Summary
+
+1. **Arbitrum leads in TVL and DeFi ecosystem depth.** The Nitro upgrade delivers near-native Ethereum compatibility, and protocols like GMX demonstrate what L2-native DeFi can achieve.
+2. **Optimism's OP Stack and Superchain strategy** transformed it from a single L2 into an L2 technology provider — its influence far exceeds its own chain's TVL.
+3. **Base leverages Coinbase's user base and regulatory standing** to become the fastest-growing L2, with a strong focus on social and consumer applications.
+4. **zkSync and StarkNet represent two paths for ZK Rollup** — zkSync pursues EVM compatibility, StarkNet builds its own Cairo ecosystem. Both lead in innovations like native account abstraction.
+5. **The L2 landscape is still evolving rapidly.** Competition across technology, ecosystem, and governance will continue driving maturity in the Ethereum scaling ecosystem.
+
+## Further Reading
+
+- [L2Beat: Layer 2 Data Dashboard](https://l2beat.com/)
+- [Ethereum Foundation: Pectra Mainnet Announcement](https://blog.ethereum.org/en/2025/04/23/pectra-mainnet)
+- [Ethereum Foundation: Fusaka Mainnet Announcement](https://blog.ethereum.org/2025/11/06/fusaka-mainnet-announcement)
+- [ethereum.org: PeerDAS](https://ethereum.org/roadmap/fusaka/peerdas)
+- [Arbitrum Documentation](https://docs.arbitrum.io/)
+- [Optimism Documentation](https://docs.optimism.io/)
+- [Base Documentation](https://docs.base.org/)
+- [zkSync Documentation](https://docs.zksync.io/)
+- [StarkNet Documentation](https://docs.starknet.io/)
+- [Vitalik: The different types of ZK-EVMs](https://vitalik.eth.limo/general/2022/08/04/zkevm.html)
+- [The Block: Layer 2 Data Dashboard](https://www.theblock.co/data/scaling-solutions)

--- a/en/L2CrossChain/04_CrossChainBridges/README.md
+++ b/en/L2CrossChain/04_CrossChainBridges/README.md
@@ -1,0 +1,487 @@
+# Cross-Chain Bridges and Interoperability
+
+![status](https://img.shields.io/badge/status-completed-success)
+![author](https://img.shields.io/badge/author-beihaili-blue)
+![date](https://img.shields.io/badge/date-2025--06-orange)
+![difficulty](https://img.shields.io/badge/difficulty-intermediate-yellow)
+
+> In a multi-chain ecosystem, cross-chain bridges are critical infrastructure connecting different blockchains. This lesson explains how bridges work, their trust models, and the leading protocols — and walks through major security incidents to build your risk awareness for cross-chain operations.
+>
+> Follow me on Twitter: [@bhbtc1337](https://twitter.com/bhbtc1337)
+>
+> Join the WeChat group: [Form Link](https://forms.gle/QMBwL6LwZyQew1tX8)
+>
+> Articles are open-sourced on GitHub: [Get-Started-with-Web3](https://github.com/beihaili/Get-Started-with-Web3)
+>
+> Recommended exchange for buying BTC / ETH / USDT: [Binance](https://www.binance.com/en) [Registration Link](https://www.bsmkweb.cc/register?ref=39797374)
+
+## Table of Contents
+
+- [Why Cross-Chain Matters](#why-cross-chain-matters)
+- [How Cross-Chain Bridges Work](#how-cross-chain-bridges-work)
+- [Bridge Trust Models](#bridge-trust-models)
+- [Leading Cross-Chain Protocols](#leading-cross-chain-protocols)
+- [Bridge Security Incidents](#bridge-security-incidents)
+- [Cross-Chain Security Best Practices](#cross-chain-security-best-practices)
+- [Summary](#summary)
+- [Further Reading](#further-reading)
+
+## Why Cross-Chain Matters
+
+### The Multi-Chain Reality
+
+Before 2020, Ethereum was nearly the only blockchain with an active DeFi ecosystem. Today the landscape looks completely different:
+
+```text
+Current multi-chain ecosystem:
+
+Ethereum L1 ──── Arbitrum
+    │            Optimism
+    │            Base
+    │            zkSync
+    │            StarkNet
+    │
+Bitcoin ──── Lightning Network
+    │        Stacks
+    │
+Solana
+    │
+BNB Chain
+    │
+Avalanche
+    │
+Polygon PoS
+    │
+Cosmos ecosystem ── Osmosis, Celestia, dYdX v4 ...
+```
+
+Liquidity and users are scattered across dozens of chains, creating three core problems:
+
+1. **Liquidity fragmentation**: the same token has different liquidity depths on different chains. Uniswap has the deepest ETH/USDC liquidity on Ethereum, but much shallower pools on Arbitrum.
+2. **Fragmented user experience**: a user with ETH on Arbitrum who wants to participate in a project on Base must first "move" their assets.
+3. **Developer dilemma**: should a DApp deploy on one chain or many? How do you manage the cost and complexity of multi-chain deployments?
+
+**Cross-chain bridges are the infrastructure that solves these problems** — they let assets and information flow between different blockchains.
+
+### The Core Challenge of Cross-Chain
+
+Cross-chain is hard because blockchains are **inherently isolated systems**. Each chain can only verify its own state; it cannot directly read state from other chains.
+
+Think of it like an international wire transfer: a bank in Mexico cannot directly access the U.S. banking system — it needs an intermediary like SWIFT to relay information and settle funds. Cross-chain bridges are the blockchain world's "SWIFT."
+
+## How Cross-Chain Bridges Work
+
+There are three core bridge mechanisms:
+
+### Mode 1: Lock-and-Mint
+
+The most common bridge pattern:
+
+```text
+Source chain (Ethereum)               Target chain (Arbitrum)
+       │                                      │
+       │  1. User sends 1 ETH                │
+       │     to the bridge contract           │
+       │                                      │
+       │  2. Bridge contract locks 1 ETH      │
+       │     ┌──────────┐                    │
+       │     │  1 ETH   │ (locked)           │
+       │     └──────────┘                    │
+       │                                      │
+       │  ──── bridge verification ──────▶   │
+       │                                      │
+       │                           3. Target chain mints
+       │                              1 wETH (wrapped)
+       │                                      │
+       │                           4. wETH sent to user
+```
+
+**Redeeming is the reverse**: the user burns wETH on the target chain, and the bridge releases the locked ETH on the source chain.
+
+**Key point**: tokens on the target chain are "wrapped" versions whose value depends entirely on the original assets locked in the bridge contract. If the bridge is exploited and the locked assets are stolen, the wrapped tokens become worthless.
+
+### Mode 2: Burn-and-Mint
+
+Used for natively multi-chain tokens (e.g., USDC's CCTP protocol):
+
+```text
+Source chain                          Target chain
+       │                                      │
+       │  1. Burn 100 USDC                   │
+       │     (true burn, not a lock)          │
+       │                                      │
+       │  ──── attestation ──────▶           │
+       │                                      │
+       │                           2. Mint 100 USDC
+       │                              (native token, not wrapped)
+```
+
+**Advantage**: no locked-asset security risk; the target chain holds native tokens, not wrapped versions.
+
+**Prerequisite**: the token issuer must have minting authority on multiple chains. Circle's CCTP (Cross-Chain Transfer Protocol) for USDC is the canonical example of this model.
+
+### Mode 3: Atomic Swap
+
+Requires no intermediary — cryptography ensures both sides either complete simultaneously or neither does:
+
+```text
+Alice (has 1 ETH on Ethereum)    Bob (has 3000 USDC on Arbitrum)
+
+Step 1: Alice generates a secret S, computes hash H = hash(S)
+Step 2: Alice creates an HTLC on Ethereum:
+        "If Bob provides S within 24h, give him 1 ETH"
+Step 3: Bob creates an HTLC on Arbitrum:
+        "If Alice provides S within 12h, give her 3000 USDC"
+Step 4: Alice uses S to claim the 3000 USDC on Arbitrum
+        (S is now public)
+Step 5: Bob uses the revealed S to claim the 1 ETH on Ethereum
+
+Timeout protection: if either party does not cooperate,
+                    funds are automatically returned after timeout
+```
+
+HTLC (Hash Time-Locked Contract) guarantees atomicity, but user experience is poor — both parties must be online simultaneously.
+
+## Bridge Trust Models
+
+The security of a bridge depends on its trust model. Bridges can be grouped into four trust tiers:
+
+### Tier 1: Native Bridge
+
+**Trusted entity**: L1 validator set (highest trust)
+
+```text
+Ethereum ↔ Rollup official bridges:
+
+Ethereum L1
+  │
+  ├── Arbitrum official bridge: asset security guaranteed by Ethereum consensus
+  ├── Optimism official bridge: fraud proofs + 7-day challenge period
+  └── zkSync official bridge:  ZK proofs + L1 verification
+```
+
+**Characteristics:**
+
+- Security is equivalent to L1 itself
+- Usually the slowest (Optimistic Rollup requires a 7-day withdrawal period)
+- Limited functionality — only supports L1 ↔ L2 transfers
+
+### Tier 2: Light-Client Verification Bridge
+
+**Trusted entity**: cryptographic proofs (high trust)
+
+The bridge runs a light client of the source chain on the target chain, confirming transactions by verifying block headers and Merkle proofs.
+
+**Representative project**: IBC (the Cosmos ecosystem's cross-chain protocol)
+
+IBC is the most mature light-client bridge in existence:
+
+- Two chains run each other's light clients.
+- Relayers carry messages, but cannot forge them.
+- Security is grounded in cryptography, not trust in the relayer.
+
+### Tier 3: Optimistic Verification Bridge
+
+**Trusted entity**: at least one honest validator (medium trust)
+
+Similar to Optimistic Rollup — assume cross-chain messages are correct and allow a challenge window.
+
+**Representative project**: Connext (now Everclear)
+
+### Tier 4: External Validation Bridge
+
+**Trusted entity**: multisig committee or Oracle network (lower trust)
+
+A set of external validators (typically a multisig wallet or Oracle nodes) collectively confirms the validity of cross-chain messages.
+
+```text
+External validation bridge:
+
+Source chain tx → Validator A ✅
+                  Validator B ✅  → threshold reached → execute on target chain
+                  Validator C ✅
+                  Validator D ❌  (offline)
+```
+
+**Characteristics:**
+
+- Fast (no challenge period or proof generation required)
+- Security depends on validator honesty and count
+- If validators are compromised or collude, assets can be stolen
+
+### Trust Model Comparison
+
+| Type                  | Security                   | Speed   | Cost   | Examples                |
+| --------------------- | -------------------------- | ------- | ------ | ----------------------- |
+| Native bridge         | Highest (= L1)             | Slowest | Medium | Rollup official bridges |
+| Light client          | High (cryptographic)       | Faster  | Higher | IBC                     |
+| Optimistic validation | Medium (1-of-N assumption) | Faster  | Medium | Connext                 |
+| External validation   | Lower (multisig / Oracle)  | Fastest | Lowest | Early Multichain        |
+
+## Leading Cross-Chain Protocols
+
+### LayerZero
+
+LayerZero is one of the most closely watched cross-chain messaging protocols today.
+
+**Core design:**
+
+```text
+LayerZero Architecture:
+
+Source app → LayerZero Endpoint (source chain)
+                    │
+                    ├── DVN (Decentralized Verifier Network)
+                    │    └── validates cross-chain messages
+                    │
+                    ├── Executor
+                    │    └── executes messages on the target chain
+                    │
+                    └── Configurable security
+                         └── apps choose their own DVN combination
+
+LayerZero Endpoint (target chain) → Target app
+```
+
+**Key improvements in V2:**
+
+- **DVN (Decentralized Verifier Networks)**: replaces V1's Oracle + Relayer model.
+- **App-configurable security**: each application selects the DVNs it trusts.
+- **Executor separation**: message verification and execution are decoupled for greater flexibility.
+
+**Coverage**: supports 50+ chains, making it one of the broadest cross-chain protocols.
+
+**ZRO token**: airdropped June 2024, used for governance and protocol fees.
+
+### Wormhole
+
+Wormhole started as a Solana-Ethereum bridge and has since expanded into a general cross-chain messaging protocol.
+
+**Core mechanism:**
+
+```text
+Wormhole Guardian Network:
+
+19 Guardian nodes (run by reputable validators)
+   │
+   ├── Observe cross-chain messages on the source chain
+   │
+   ├── Each Guardian signs to confirm
+   │
+   └── 2/3 supermajority reached (13/19) → VAA (Verified Action Approval) generated
+                                               │
+                                               ▼
+                                    Target chain verifies VAA and executes
+```
+
+**Characteristics:**
+
+- Guardians run by institutions including Jump Crypto and Staked.
+- Fast (typically 1–5 minutes).
+- Security depends on Guardian honesty and operational security.
+- Suffered a $320M exploit in 2022 (detailed below).
+
+**W token**: launched April 2024.
+
+### Axelar
+
+Axelar positions itself as "the full-stack interoperability layer for Web3."
+
+**Core technology:**
+
+- Built on the **Cosmos SDK** as a PoS chain — Axelar itself is a blockchain dedicated to cross-chain work.
+- **Validator set**: secured by staking and slashing, like other PoS chains.
+- **GMP (General Message Passing)**: supports arbitrary cross-chain messages, not just asset transfers.
+
+```text
+Axelar and the Cosmos relationship:
+
+Cosmos Hub ─── IBC ─── Axelar Network ─── Gateway contracts ─── EVM chains
+                              │
+                              └── validators run light clients for all connected chains
+```
+
+**Unique advantage**: bridges the Cosmos ecosystem and the EVM ecosystem, filling the gap between the two largest blockchain communities.
+
+### Connext (now Everclear)
+
+Connext uses a distinctive "chain abstraction" philosophy:
+
+**Core design:**
+
+- **Intent-based**: the user expresses "I want to convert token A on chain X into token B on chain Y."
+- **Router network**: liquidity providers pre-position funds on each chain.
+- **Optimistic verification**: uses an optimistic mechanism to validate cross-chain messages.
+
+```text
+User intent: "Move 1 ETH from Arbitrum to Base"
+
+Router network:
+  Router A (Arbitrum): has ETH liquidity
+  Router B (Base):     has ETH liquidity
+
+Flow:
+  1. User locks 1 ETH on Arbitrum
+  2. Router B immediately releases 1 ETH to the user on Base (minus fee)
+  3. Router B later reclaims the locked ETH from Arbitrum after verification
+```
+
+**Advantage**: excellent UX (near-instant), but requires routers to pre-fund liquidity.
+
+## Bridge Security Incidents
+
+Cross-chain bridges are hackers' favorite targets for one simple reason — bridge contracts hold enormous amounts of locked assets, and a single exploit can yield massive profit.
+
+### Ronin Bridge: $625M (March 2022)
+
+**Background**: Ronin is the sidechain for Axie Infinity (a Play-to-Earn game).
+
+**Attack walkthrough:**
+
+```text
+Ronin Bridge security model:
+  9 validators, 5-of-9 multisig controls the bridge
+
+Attacker (North Korean Lazarus Group):
+  1. Used social engineering (spear-phishing disguised as a recruiter)
+     to obtain private keys for 4 validators
+  2. Used a legacy Axie DAO approval to obtain a 5th signature
+  3. Controlled 5/9 — enough to withdraw any amount from the bridge
+  4. Drained 173,600 ETH + 25.5M USDC ≈ $625M
+
+Root cause:
+  - 4 of the 9 validators were run by the same entity (Sky Mavis)
+  - The attack went undetected for 6 days
+    (discovered only when users couldn't withdraw)
+```
+
+**Lesson**: validator diversity matters more than validator count; anomalous withdrawals need real-time monitoring.
+
+### Wormhole: $320M (February 2022)
+
+**Attack type**: smart contract vulnerability
+
+```text
+Vulnerability details:
+  Wormhole's Solana-side contract had a signature verification flaw:
+
+  Normal flow: user locks ETH on Ethereum → Guardian confirms
+               → Solana mints wETH
+
+  Attack flow:
+  1. Attacker crafted a fake "Guardian signature verification" instruction
+  2. Exploited a bug in Solana's secp256k1 signature verification precompile
+  3. Bypassed Guardian signature checks entirely
+  4. Minted 120,000 wETH from thin air on Solana (worth $320M)
+  5. Bridged a portion back to Ethereum to redeem real ETH
+```
+
+**Aftermath**: Jump Crypto (Wormhole's primary backer) covered the $320M shortfall out of pocket.
+
+### Nomad: $190M (August 2022)
+
+**Attack type**: smart contract misconfiguration — and the most unusual thing about this incident is that it became a "crowd robbery."
+
+```text
+Vulnerability:
+  Nomad initialized the Merkle root to 0x00 during an upgrade.
+  This caused every message to validate as "valid."
+
+Attack spread:
+  1. One hacker discovered the bug and began draining funds
+  2. Others saw the attack transactions on-chain
+  3. The exploit was trivially easy: just copy the attacker's transaction,
+     change the recipient address
+  4. Hundreds of addresses joined the drain
+  5. ~$190M was extracted by hundreds of different addresses
+```
+
+This incident was dubbed "the first decentralized bank robbery" — anyone could participate by copy-pasting a transaction.
+
+### Attack Summary
+
+| Incident        | Date          | Loss  | Attack Type            | Root Cause                                   |
+| --------------- | ------------- | ----- | ---------------------- | -------------------------------------------- |
+| Ronin Bridge    | March 2022    | $625M | Private key theft      | Concentrated validators + social engineering |
+| Wormhole        | February 2022 | $320M | Contract vulnerability | Signature verification bypass                |
+| Nomad           | August 2022   | $190M | Misconfiguration       | Merkle root initialized to zero              |
+| Harmony Horizon | June 2022     | $100M | Private key theft      | 2-of-5 multisig — threshold too low          |
+| Multichain      | July 2023     | $126M | Insider                | CEO controlled all private keys              |
+
+Cross-chain bridge exploits caused over **$2 billion** in losses in 2022 alone.
+
+## Cross-Chain Security Best Practices
+
+Based on the incidents above, here is what an ordinary user should keep in mind when using bridges:
+
+### 1. Prefer Official Bridges
+
+```text
+Security tiers (highest to lowest):
+
+1. Rollup official bridges (Arbitrum Bridge, OP Bridge)
+   └── Security equivalent to L1, but slow
+
+2. Circle CCTP (native USDC cross-chain)
+   └── Operated by the USDC issuer, Burn-and-Mint model
+
+3. Established third-party bridges (Stargate, Across, Hop)
+   └── Protocols with long track records
+
+4. Newer / niche bridges
+   └── Use with caution — check audit reports first
+```
+
+### 2. Split Large Transfers
+
+Don't move all your assets through a single bridge in one transaction:
+
+- Test with a small amount first to confirm the bridge works.
+- Transfer the remainder only after confirming receipt.
+- Consider using different bridges to spread risk.
+
+### 3. Check the Bridge's Security Status
+
+Before using any bridge, verify:
+
+- **Audit reports**: has it been audited by a reputable security firm?
+- **TVL trend**: is TVL stable or growing? A sudden drop can be a warning sign.
+- **Bug bounty**: does the project have an active bounty program?
+- **L2Beat risk assessment**: L2Beat provides detailed security scores for bridges.
+
+### 4. Understand Wrapped Token Risk
+
+```text
+Not all "USDC" is the same:
+
+Native USDC on Ethereum (issued by Circle)       = real USDC
+USDC.e via Arbitrum's official bridge             = bridged wrapped USDC
+Native USDC on Arbitrum (via Circle CCTP)         = real USDC
+USDC via a small third-party bridge               = security depends on that bridge
+```
+
+Make sure the tokens you hold come from a trusted bridge or native issuance.
+
+### 5. Monitor Approvals and Interactions
+
+- Regularly review the token approvals you've granted to bridge contracts (use Revoke.cash).
+- After bridging, revoke the approval if you no longer intend to use that bridge.
+- Don't leave assets sitting in bridge contracts long-term.
+
+## Summary
+
+1. **Cross-chain is a fundamental need in the multi-chain ecosystem.** Liquidity fragmentation, user experience gaps, and developer complexity all require bridges to solve.
+2. **Three core mechanisms**: Lock-and-Mint (most common), Burn-and-Mint (most secure, but requires issuer support), Atomic Swap (trustless, but poor UX).
+3. **Trust model tiers from highest to lowest**: Native bridge > Light-client verification > Optimistic validation > External validation. Security and speed are almost always a trade-off.
+4. **Bridges are high-value attack targets.** Ronin ($625M), Wormhole ($320M), and Nomad ($190M) show that bridge security design is critical.
+5. **Users should default to official bridges and proven protocols**, split large transfers, and check audit reports and security assessments before using anything new.
+
+## Further Reading
+
+- [Vitalik: Why the future will be multi-chain, but not cross-chain](https://old.reddit.com/r/ethereum/comments/rwojtk/ama_we_are_the_efs_research_team_pt_7_07_january/hrngyk8/)
+- [L2Beat: Bridges Risk Assessment](https://l2beat.com/bridges/risk)
+- [LayerZero Documentation](https://docs.layerzero.network/)
+- [Wormhole Documentation](https://docs.wormhole.com/)
+- [Axelar Documentation](https://docs.axelar.dev/)
+- [Rekt News: Cross-chain bridge incident archive](https://rekt.news/)
+- [Chainalysis: Cross-chain Bridge Hacks](https://www.chainalysis.com/blog/cross-chain-bridge-hacks-2022/)

--- a/en/L2CrossChain/05_L2PracticalGuide/README.md
+++ b/en/L2CrossChain/05_L2PracticalGuide/README.md
@@ -1,0 +1,472 @@
+# L2 Practical Guide
+
+![status](https://img.shields.io/badge/status-completed-success)
+![author](https://img.shields.io/badge/author-beihaili-blue)
+![date](https://img.shields.io/badge/date-2025--06-orange)
+![difficulty](https://img.shields.io/badge/difficulty-intermediate-yellow)
+
+> Four lessons of theory — now it's time to act. This lesson walks you step by step through bridging assets to L2, configuring your wallet, using DeFi, and using real Gas fee data to help you make the best chain-selection decisions.
+>
+> Follow me on Twitter: [@bhbtc1337](https://twitter.com/bhbtc1337)
+>
+> Join the WeChat group: [Form Link](https://forms.gle/QMBwL6LwZyQew1tX8)
+>
+> Articles are open-sourced on GitHub: [Get-Started-with-Web3](https://github.com/beihaili/Get-Started-with-Web3)
+>
+> Recommended exchange for buying BTC / ETH / USDT: [Binance](https://www.binance.com/en) [Registration Link](https://www.bsmkweb.cc/register?ref=39797374)
+
+## Table of Contents
+
+- [Bridging Assets from Ethereum to L2](#bridging-assets-from-ethereum-to-l2)
+- [Adding L2 Networks to MetaMask](#adding-l2-networks-to-metamask)
+- [Using DeFi on L2](#using-defi-on-l2)
+- [Gas Fee Comparison](#gas-fee-comparison)
+- [Chain Selection Strategy](#chain-selection-strategy)
+- [Common Pitfalls on L2](#common-pitfalls-on-l2)
+- [Summary](#summary)
+- [Further Reading](#further-reading)
+
+## Bridging Assets from Ethereum to L2
+
+We'll use the Arbitrum official bridge as a concrete example of how to move ETH from Ethereum mainnet to Arbitrum One.
+
+### Using the Arbitrum Official Bridge
+
+**Step 1: Go to the official bridge**
+
+Open [bridge.arbitrum.io](https://bridge.arbitrum.io/) and connect your MetaMask wallet.
+
+> **Security reminder**: Always confirm you are on the official URL. Phishing sites are one of the most common causes of asset loss. Bookmark the official bridge address in your browser.
+
+**Step 2: Choose the direction and amount**
+
+```text
+Bridge interface:
+
+From: Ethereum Mainnet
+  └── Select token: ETH
+  └── Enter amount: 0.1 ETH (start small for testing)
+
+To: Arbitrum One
+  └── Estimated received amount is shown automatically
+
+Estimated costs:
+  └── L1 Gas fee: ~$3–15 (depends on mainnet congestion)
+  └── Bridge time: ~10–15 minutes
+```
+
+**Step 3: Confirm the transaction**
+
+MetaMask will pop up a transaction confirmation window showing:
+
+- Transaction amount
+- Estimated Gas fee
+- Target contract address (verify it is the Arbitrum official bridge contract)
+
+Click confirm, then wait for Ethereum mainnet to finalize the transaction.
+
+**Step 4: Wait for funds to arrive**
+
+```text
+Bridge progress:
+
+L1 → L2 (deposit direction):
+  Ethereum confirmation (~2 min) → Arbitrum confirmation (~10 min)
+  Total: ~10–15 minutes
+
+L2 → L1 (withdrawal direction):
+  Initiate on Arbitrum → 7-day challenge period → Ethereum confirmation
+  Total: ~7 days
+```
+
+Deposits (L1→L2) typically take 10–15 minutes. Withdrawals (L2→L1) require the full 7-day challenge period — this is an intentional security property of Optimistic Rollup.
+
+### Using Third-Party Bridges for Faster Withdrawals
+
+If you cannot wait 7 days, third-party bridges offer fast withdrawals:
+
+| Bridge                   | Withdrawal Time | Fee        | Best For               |
+| ------------------------ | --------------- | ---------- | ---------------------- |
+| Arbitrum Official Bridge | 7 days          | Gas only   | Large amounts, no rush |
+| Hop Protocol             | 5–20 minutes    | 0.04–0.1%  | Mid-range amounts      |
+| Across Protocol          | 1–5 minutes     | 0.06–0.12% | Speed priority         |
+| Stargate (LayerZero)     | 1–10 minutes    | 0.06%      | Multi-chain needs      |
+
+Third-party bridges work by pre-positioning liquidity on L1. You send assets to the bridge on L2; the bridge immediately releases equivalent funds to you on L1. The bridge later reclaims the assets through the official bridge after the 7-day period.
+
+## Adding L2 Networks to MetaMask
+
+Most L2 networks are not supported by MetaMask by default and must be added manually.
+
+### Method 1: One-Click via ChainList
+
+The easiest method is [chainlist.org](https://chainlist.org/):
+
+1. Connect MetaMask
+2. Search for the network name
+3. Click **Add to MetaMask**
+4. Approve in the MetaMask popup
+
+### Method 2: Manual Configuration
+
+If you prefer to configure manually (or want to verify parameters yourself), here are the network parameters for all major L2s:
+
+**Arbitrum One**
+
+```text
+Network Name:  Arbitrum One
+RPC URL:       https://arb1.arbitrum.io/rpc
+Chain ID:      42161
+Currency:      ETH
+Block Explorer: https://arbiscan.io
+```
+
+**Optimism**
+
+```text
+Network Name:  OP Mainnet
+RPC URL:       https://mainnet.optimism.io
+Chain ID:      10
+Currency:      ETH
+Block Explorer: https://optimistic.etherscan.io
+```
+
+**Base**
+
+```text
+Network Name:  Base
+RPC URL:       https://mainnet.base.org
+Chain ID:      8453
+Currency:      ETH
+Block Explorer: https://basescan.org
+```
+
+**zkSync Era**
+
+```text
+Network Name:  zkSync Era Mainnet
+RPC URL:       https://mainnet.era.zksync.io
+Chain ID:      324
+Currency:      ETH
+Block Explorer: https://explorer.zksync.io
+```
+
+**StarkNet**
+
+> Note: StarkNet uses a different account model and cannot be added to MetaMask directly. You need a dedicated wallet: **Argent X** or **Braavos**.
+
+```text
+Argent X:  https://www.argent.xyz/argent-x/
+Braavos:   https://braavos.app/
+```
+
+### Method 3: Auto-Add via DApp Prompt
+
+When you visit a DApp on L2, it will usually prompt you to switch networks. Click the **Switch Network** button in that prompt and MetaMask will add the configuration automatically.
+
+> **Security reminder**: Regardless of which method you use, always verify the RPC URL and Chain ID. A malicious RPC can spoof your displayed balance (it cannot steal assets, but it causes confusion). Use only RPC nodes listed in official documentation.
+
+## Using DeFi on L2
+
+We'll walk through swapping tokens on Uniswap on Arbitrum as a hands-on example.
+
+### Step 1: Ensure you have ETH for Gas
+
+On Arbitrum, Gas is paid in ETH. Make sure your Arbitrum account holds some ETH:
+
+- Simple transfer: ~$0.001–0.01
+- DEX swap: ~$0.01–0.10
+- Complex contract interaction: ~$0.05–0.30
+
+Keep at least 0.001 ETH (~$3–5) as a Gas reserve.
+
+### Step 2: Open Uniswap
+
+1. Go to [app.uniswap.org](https://app.uniswap.org/)
+2. Connect MetaMask
+3. **Switch to the Arbitrum network** — click the network selector in the top-right corner and select Arbitrum
+
+```text
+Uniswap multi-chain support:
+
+Ethereum    ✓  (most expensive Gas)
+Arbitrum    ✓  (recommended — deep liquidity)
+Optimism    ✓
+Base        ✓  (recommended — lowest fees)
+Polygon     ✓
+BNB Chain   ✓
+```
+
+### Step 3: Execute the swap
+
+For example, swapping 0.01 ETH for USDC:
+
+```text
+Swap interface:
+
+You pay:     0.01 ETH
+You receive: ~30 USDC (based on live price)
+
+Transaction details:
+├── Rate:           1 ETH ≈ 3000 USDC
+├── Price impact:   <0.01% (sufficient liquidity)
+├── Minimum out:    29.85 USDC (0.5% slippage protection)
+├── Route:          ETH → WETH → USDC (direct path)
+└── Estimated Gas:  $0.03
+```
+
+Click **Swap** → confirm in MetaMask → wait a few seconds → done.
+
+### Step 4: Verify the transaction
+
+After the swap, inspect it on a block explorer:
+
+- Arbitrum: [arbiscan.io](https://arbiscan.io/)
+- Optimism: [optimistic.etherscan.io](https://optimistic.etherscan.io/)
+- Base: [basescan.org](https://basescan.org/)
+
+Enter your wallet address to see all transactions, including the hash, tokens sent/received, Gas cost, and status.
+
+### Other Common DeFi Operations
+
+| Operation        | Recommended Protocol (Arbitrum) | Typical Gas |
+| ---------------- | ------------------------------- | ----------- |
+| Token swap       | Uniswap, Camelot                | $0.01–0.10  |
+| Lending          | Aave, Radiant                   | $0.05–0.20  |
+| Perpetuals       | GMX, Vertex                     | $0.05–0.30  |
+| Liquidity mining | Camelot, Pendle                 | $0.05–0.30  |
+| NFT trading      | Treasure Marketplace            | $0.01–0.10  |
+
+## Gas Fee Comparison
+
+The following data reflects the same operations across chains after the EIP-4844 upgrade (reference values):
+
+### ETH Transfer
+
+| Chain       | Gas Fee       | Confirmation Time |
+| ----------- | ------------- | ----------------- |
+| Ethereum L1 | $0.50–5.00    | 12 seconds        |
+| Arbitrum    | $0.001–0.01   | 0.3 seconds       |
+| Optimism    | $0.001–0.01   | 2 seconds         |
+| Base        | $0.0005–0.005 | 2 seconds         |
+| zkSync Era  | $0.001–0.01   | seconds           |
+
+### Uniswap Swap
+
+| Chain       | Gas Fee     | Confirmation Time |
+| ----------- | ----------- | ----------------- |
+| Ethereum L1 | $3–30       | 12 seconds        |
+| Arbitrum    | $0.01–0.10  | 0.3 seconds       |
+| Optimism    | $0.01–0.10  | 2 seconds         |
+| Base        | $0.005–0.05 | 2 seconds         |
+| zkSync Era  | $0.02–0.15  | seconds           |
+
+### Key Takeaway
+
+```text
+Gas cost reduction (L2 vs L1):
+
+Simple transfer:   100–500x cheaper
+DEX swap:          100–300x cheaper
+Complex contract:   50–200x cheaper
+
+Bottom line: L2 makes DeFi viable for small-capital users again
+  L1: $100 operation + $30 Gas = 30% overhead
+  L2: $100 operation + $0.05 Gas = 0.05% overhead
+```
+
+> Note: these figures are reference values. Actual Gas fees fluctuate with network congestion and ETH price. Use [l2fees.info](https://l2fees.info/) for real-time comparisons.
+
+## Chain Selection Strategy
+
+Different use cases call for different chains. Here is a practical decision framework:
+
+### Scenario 1: DeFi Trading (Large Amounts)
+
+```text
+Recommended: Arbitrum
+Reasons:
+  ├── Deepest DeFi liquidity, lowest slippage
+  ├── All major protocols present: GMX, Aave, Uniswap
+  ├── High-volume DEX pools mean better prices
+  └── Best for trades $1,000+
+```
+
+### Scenario 2: DeFi Trading (Small Amounts / High Frequency)
+
+```text
+Recommended: Base
+Reasons:
+  ├── Lowest Gas fees
+  ├── Coinbase users can deposit fiat directly
+  ├── Aerodrome and other native DEXes growing rapidly
+  └── Best for $10–1,000 trades and frequent activity
+```
+
+### Scenario 3: NFTs and Social Apps
+
+```text
+Recommended: Base or Arbitrum Nova
+Reasons:
+  ├── Base: Farcaster ecosystem, mint.fun
+  ├── Arbitrum Nova: designed for low-value, high-frequency activity
+  └── Both offer near-zero Gas — ideal for frequent mints and social interactions
+```
+
+### Scenario 4: Developers Deploying a DApp
+
+```text
+EVM compatibility first: Arbitrum / Optimism / Base
+  └── Deploy Solidity directly — full toolchain compatibility
+
+ZK-native capabilities: zkSync / StarkNet
+  └── If the project needs ZK proofs or native account abstraction
+
+Multi-chain deployment: OP Stack or Arbitrum Orbit
+  └── If the project needs its own app-chain
+```
+
+### Scenario 5: Long-Term Asset Holding (Large Amounts)
+
+```text
+Recommended: Ethereum L1
+Reasons:
+  ├── Highest security
+  ├── No dependency on any L2's correct operation
+  └── Best for "cold storage" of large holdings
+
+Second choice: Arbitrum / Optimism (via official bridge)
+  └── If you need to earn DeFi yield on L2
+```
+
+### Chain Selection Decision Tree
+
+```text
+What do you want to do?
+│
+├── Hold large assets long-term → Ethereum L1
+│
+├── Active DeFi trading
+│   ├── Large amounts ($1,000+) → Arbitrum
+│   └── Small amounts / high frequency → Base
+│
+├── NFTs / social apps → Base
+│
+├── Develop a DApp
+│   ├── EVM compatibility needed → Arbitrum / Base
+│   └── ZK capabilities needed → zkSync / StarkNet
+│
+└── Cross-chain activity
+    ├── L1 ↔ L2 → Official bridge (safest)
+    └── L2 ↔ L2 → Across / Stargate (fastest)
+```
+
+## Common Pitfalls on L2
+
+### Pitfall 1: Wrapped Token Confusion
+
+```text
+The same "USDC" may exist in multiple versions:
+
+On Arbitrum:
+  USDC (native)  = issued by Circle via CCTP             ✓ Recommended
+  USDC.e (bridged) = bridged from L1 via Arbitrum bridge ⚠ Legacy version
+
+How to tell them apart:
+  └── Check the token contract address — confirm it is the Circle official deployment
+  └── USDC.e has a different contract address from native USDC
+```
+
+Many DeFi protocols support both USDC versions, but their liquidity pools are separate. Always confirm which version you are using.
+
+### Pitfall 2: Running Out of Gas
+
+```text
+Common mistake:
+  User swaps all ETH for USDC
+  → No ETH left to pay Gas
+  → Cannot do anything (including swapping back to ETH)
+
+Solutions:
+  1. Always keep 0.002+ ETH as a Gas reserve
+  2. Use DApps that support Paymaster (common on zkSync)
+  3. Withdraw ETH directly from an exchange to L2
+```
+
+### Pitfall 3: Sequencer Single Point of Failure
+
+Most L2 sequencers currently run in a centralized configuration:
+
+```text
+What happens if the sequencer goes down:
+
+1. No new transactions can be submitted (L2 pauses)
+2. Existing funds are not affected
+3. Users can exit funds via L1 "force-inclusion" mechanism
+   (complex, but available as a last resort)
+
+Real examples:
+  - Arbitrum experienced ~1 hour of downtime due to sequencer failure
+  - All major L2s are actively working toward sequencer decentralization
+```
+
+### Pitfall 4: Misjudging Cross-Chain Timing
+
+```text
+Actual wait times when withdrawing from L2 to L1:
+
+Optimistic Rollup (Arbitrum / Optimism / Base):
+  Official bridge:      7 days (not "approximately" — strictly 7 days)
+  Third-party bridge:   1–20 minutes
+
+ZK Rollup (zkSync / StarkNet):
+  Official bridge:      minutes to hours (depends on proof generation)
+  Typical experience:   15–60 minutes
+```
+
+### Pitfall 5: Unstable RPC Nodes
+
+```text
+Problem:  Public RPC nodes can become congested or unresponsive
+Symptoms: Stuck transactions, incorrect balance display, connection failures
+
+Solutions:
+  1. Add backup RPC nodes in MetaMask
+  2. Use professional RPC services: Alchemy, Infura, QuickNode
+  3. Arbitrum recommended RPCs:
+     - https://arb1.arbitrum.io/rpc     (official)
+     - https://arbitrum-one.publicnode.com  (public backup)
+     - Private Alchemy / Infura node    (most stable)
+```
+
+### Pitfall 6: Token Approval Management Across Chains
+
+```text
+Problem:  Using DeFi across many chains generates large numbers of token approvals
+Risk:     If a protocol is exploited, your approved tokens may be drained
+
+Best practices:
+  1. Use Revoke.cash to audit and revoke approvals
+  2. Prefer "exact approval" amounts over unlimited approvals
+  3. Periodically clean up approvals for protocols you no longer use
+  4. Check each chain separately — approvals do not transfer across chains
+```
+
+## Summary
+
+1. **The official bridge is the safest bridging method** (using Arbitrum Bridge as an example): L1→L2 takes ~10 minutes, L2→L1 requires 7 days; third-party bridges are faster but introduce additional trust assumptions.
+2. **Adding L2 networks to MetaMask** has three methods: ChainList one-click (easiest), manual parameter entry (most control), DApp auto-prompt (most convenient).
+3. **DeFi on L2 already feels close to Web2** — swapping on Uniswap on Arbitrum costs $0.01–0.10 in Gas and confirms in seconds.
+4. **Gas fees on L2 are 100–500x lower than L1**, making DeFi viable for users with smaller capital.
+5. **Chain selection**: large DeFi positions on Arbitrum, small/frequent activity on Base, long-term holdings on L1, cutting-edge development on zkSync/StarkNet.
+6. **Watch out for common pitfalls**: wrapped token confusion, forgetting to reserve Gas, sequencer risk, cross-chain timing assumptions, unstable RPC nodes, and token approval management.
+
+## Further Reading
+
+- [Arbitrum Bridge Official Guide](https://bridge.arbitrum.io/)
+- [ChainList: One-Click Network Addition](https://chainlist.org/)
+- [L2Fees: Real-Time Gas Fee Comparison](https://l2fees.info/)
+- [Revoke.cash: Token Approval Manager](https://revoke.cash/)
+- [DefiLlama: Multi-Chain DeFi Data](https://defillama.com/)
+- [Uniswap Official Documentation](https://docs.uniswap.org/)
+- [MetaMask: How to Add a Custom Network](https://support.metamask.io/networks-and-sidechains/managing-networks/how-to-add-a-custom-network-rpc/)

--- a/public/ai/content-index.json
+++ b/public/ai/content-index.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2026-05-09",
-  "generatedAt": "2026-05-19T07:20:59.655Z",
+  "generatedAt": "2026-05-19T10:57:56.815Z",
   "repository": {
     "name": "Get-Started-with-Web3",
     "owner": "beihaili",
@@ -753,7 +753,7 @@
           "labUrl": null,
           "availability": {
             "zh": true,
-            "en": false
+            "en": true
           },
           "siteUrls": {
             "zh": "https://beihaili.github.io/Get-Started-with-Web3/zh/learn/module-9/9-3",
@@ -767,7 +767,7 @@
           "labUrl": null,
           "availability": {
             "zh": true,
-            "en": false
+            "en": true
           },
           "siteUrls": {
             "zh": "https://beihaili.github.io/Get-Started-with-Web3/zh/learn/module-9/9-4",
@@ -781,7 +781,7 @@
           "labUrl": null,
           "availability": {
             "zh": true,
-            "en": false
+            "en": true
           },
           "siteUrls": {
             "zh": "https://beihaili.github.io/Get-Started-with-Web3/zh/learn/module-9/9-5",
@@ -15794,6 +15794,179 @@
       "characterCount": 11411
     },
     {
+      "id": "en/module-9/9-3",
+      "lang": "en",
+      "moduleId": "module-9",
+      "moduleTitle": "跨链与 Layer 2 深度解析",
+      "lessonId": "9-3",
+      "title": "主流 L2 生态对比",
+      "path": "L2CrossChain/03_L2Ecosystem",
+      "labUrl": null,
+      "sourcePath": "en/L2CrossChain/03_L2Ecosystem/README.md",
+      "citation": {
+        "file": "en/L2CrossChain/03_L2Ecosystem/README.md",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/en/L2CrossChain/03_L2Ecosystem/README.md",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/en/learn/module-9/9-3"
+      },
+      "excerpt": "The Major L2 Ecosystem Compared The Ethereum L2 ecosystem is thriving — each major Rollup has carved out its own niche in architecture, ecosystem building, and growth strategy. This lesson takes a deep look at five leading L2s: Arbitrum, Optimism, Base, zkSync, and StarkNet, so you can build a complete picture of the landscape. Follow me on Twitter: @bhbtc1337 Join the WeChat group: Form Link Articles are open source",
+      "headings": [
+        {
+          "level": 1,
+          "text": "The Major L2 Ecosystem Compared"
+        },
+        {
+          "level": 2,
+          "text": "Table of Contents"
+        },
+        {
+          "level": 2,
+          "text": "Arbitrum"
+        },
+        {
+          "level": 3,
+          "text": "Architecture"
+        },
+        {
+          "level": 3,
+          "text": "Arbitrum's Multi-Chain Strategy"
+        },
+        {
+          "level": 3,
+          "text": "Ecosystem Highlights"
+        },
+        {
+          "level": 3,
+          "text": "Governance: ARB Token"
+        },
+        {
+          "level": 2,
+          "text": "Optimism"
+        },
+        {
+          "level": 3,
+          "text": "Architecture"
+        },
+        {
+          "level": 3,
+          "text": "OP Stack and the Superchain Vision"
+        },
+        {
+          "level": 3,
+          "text": "OP Token and RetroPGF"
+        },
+        {
+          "level": 2,
+          "text": "Base"
+        },
+        {
+          "level": 3,
+          "text": "Coinbase's L2 Strategy"
+        },
+        {
+          "level": 3,
+          "text": "Base and OP Stack"
+        },
+        {
+          "level": 3,
+          "text": "Base Ecosystem"
+        },
+        {
+          "level": 2,
+          "text": "zkSync"
+        },
+        {
+          "level": 3,
+          "text": "The zkEVM Approach"
+        },
+        {
+          "level": 3,
+          "text": "Native Account Abstraction"
+        },
+        {
+          "level": 3,
+          "text": "ZK Token"
+        },
+        {
+          "level": 2,
+          "text": "StarkNet"
+        },
+        {
+          "level": 3,
+          "text": "StarkEx vs StarkNet"
+        },
+        {
+          "level": 3,
+          "text": "The Cairo Language"
+        },
+        {
+          "level": 3,
+          "text": "StarkNet's Technical Advantages"
+        },
+        {
+          "level": 3,
+          "text": "STRK Token"
+        },
+        {
+          "level": 2,
+          "text": "2026 Update: Blobs, PeerDAS, and L2 Risk Tiers"
+        },
+        {
+          "level": 3,
+          "text": "Blob Economics: Why L2s Became Cheap"
+        },
+        {
+          "level": 3,
+          "text": "PeerDAS: Scaling Without Sacrificing Node Accessibility"
+        },
+        {
+          "level": 3,
+          "text": "OP Superchain and the App-Chain Trend"
+        },
+        {
+          "level": 3,
+          "text": "Base: The Consumer L2"
+        },
+        {
+          "level": 3,
+          "text": "ZK Rollup: Strong Tech, but Ecosystem and Compatibility Still Challenges"
+        },
+        {
+          "level": 3,
+          "text": "Alt-DA, Validium, and the Difference from Rollup"
+        },
+        {
+          "level": 3,
+          "text": "A Risk Framework for Choosing an L2"
+        },
+        {
+          "level": 2,
+          "text": "Comprehensive L2 Comparison"
+        },
+        {
+          "level": 3,
+          "text": "Technical Comparison"
+        },
+        {
+          "level": 3,
+          "text": "Ecosystem Data (early 2025 reference)"
+        },
+        {
+          "level": 3,
+          "text": "How to Choose an L2?"
+        },
+        {
+          "level": 2,
+          "text": "Summary"
+        },
+        {
+          "level": 2,
+          "text": "Further Reading"
+        }
+      ],
+      "codeBlockCount": 7,
+      "characterCount": 22380
+    },
+    {
       "id": "zh/module-9/9-4",
       "lang": "zh",
       "moduleId": "module-9",
@@ -15945,6 +16118,159 @@
       ],
       "codeBlockCount": 15,
       "characterCount": 10015
+    },
+    {
+      "id": "en/module-9/9-4",
+      "lang": "en",
+      "moduleId": "module-9",
+      "moduleTitle": "跨链与 Layer 2 深度解析",
+      "lessonId": "9-4",
+      "title": "跨链桥与互操作性",
+      "path": "L2CrossChain/04_CrossChainBridges",
+      "labUrl": null,
+      "sourcePath": "en/L2CrossChain/04_CrossChainBridges/README.md",
+      "citation": {
+        "file": "en/L2CrossChain/04_CrossChainBridges/README.md",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/en/L2CrossChain/04_CrossChainBridges/README.md",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/en/learn/module-9/9-4"
+      },
+      "excerpt": "Cross Chain Bridges and Interoperability In a multi chain ecosystem, cross chain bridges are critical infrastructure connecting different blockchains. This lesson explains how bridges work, their trust models, and the leading protocols — and walks through major security incidents to build your risk awareness for cross chain operations. Follow me on Twitter: @bhbtc1337 Join the WeChat group: Form Link Articles are ope",
+      "headings": [
+        {
+          "level": 1,
+          "text": "Cross-Chain Bridges and Interoperability"
+        },
+        {
+          "level": 2,
+          "text": "Table of Contents"
+        },
+        {
+          "level": 2,
+          "text": "Why Cross-Chain Matters"
+        },
+        {
+          "level": 3,
+          "text": "The Multi-Chain Reality"
+        },
+        {
+          "level": 3,
+          "text": "The Core Challenge of Cross-Chain"
+        },
+        {
+          "level": 2,
+          "text": "How Cross-Chain Bridges Work"
+        },
+        {
+          "level": 3,
+          "text": "Mode 1: Lock-and-Mint"
+        },
+        {
+          "level": 3,
+          "text": "Mode 2: Burn-and-Mint"
+        },
+        {
+          "level": 3,
+          "text": "Mode 3: Atomic Swap"
+        },
+        {
+          "level": 2,
+          "text": "Bridge Trust Models"
+        },
+        {
+          "level": 3,
+          "text": "Tier 1: Native Bridge"
+        },
+        {
+          "level": 3,
+          "text": "Tier 2: Light-Client Verification Bridge"
+        },
+        {
+          "level": 3,
+          "text": "Tier 3: Optimistic Verification Bridge"
+        },
+        {
+          "level": 3,
+          "text": "Tier 4: External Validation Bridge"
+        },
+        {
+          "level": 3,
+          "text": "Trust Model Comparison"
+        },
+        {
+          "level": 2,
+          "text": "Leading Cross-Chain Protocols"
+        },
+        {
+          "level": 3,
+          "text": "LayerZero"
+        },
+        {
+          "level": 3,
+          "text": "Wormhole"
+        },
+        {
+          "level": 3,
+          "text": "Axelar"
+        },
+        {
+          "level": 3,
+          "text": "Connext (now Everclear)"
+        },
+        {
+          "level": 2,
+          "text": "Bridge Security Incidents"
+        },
+        {
+          "level": 3,
+          "text": "Ronin Bridge: $625M (March 2022)"
+        },
+        {
+          "level": 3,
+          "text": "Wormhole: $320M (February 2022)"
+        },
+        {
+          "level": 3,
+          "text": "Nomad: $190M (August 2022)"
+        },
+        {
+          "level": 3,
+          "text": "Attack Summary"
+        },
+        {
+          "level": 2,
+          "text": "Cross-Chain Security Best Practices"
+        },
+        {
+          "level": 3,
+          "text": "1. Prefer Official Bridges"
+        },
+        {
+          "level": 3,
+          "text": "2. Split Large Transfers"
+        },
+        {
+          "level": 3,
+          "text": "3. Check the Bridge's Security Status"
+        },
+        {
+          "level": 3,
+          "text": "4. Understand Wrapped Token Risk"
+        },
+        {
+          "level": 3,
+          "text": "5. Monitor Approvals and Interactions"
+        },
+        {
+          "level": 2,
+          "text": "Summary"
+        },
+        {
+          "level": 2,
+          "text": "Further Reading"
+        }
+      ],
+      "codeBlockCount": 15,
+      "characterCount": 19539
     },
     {
       "id": "zh/module-9/9-5",
@@ -16106,6 +16432,167 @@
       ],
       "codeBlockCount": 22,
       "characterCount": 8836
+    },
+    {
+      "id": "en/module-9/9-5",
+      "lang": "en",
+      "moduleId": "module-9",
+      "moduleTitle": "跨链与 Layer 2 深度解析",
+      "lessonId": "9-5",
+      "title": "L2 实操指南",
+      "path": "L2CrossChain/05_L2PracticalGuide",
+      "labUrl": null,
+      "sourcePath": "en/L2CrossChain/05_L2PracticalGuide/README.md",
+      "citation": {
+        "file": "en/L2CrossChain/05_L2PracticalGuide/README.md",
+        "githubUrl": "https://github.com/beihaili/Get-Started-with-Web3/blob/main/en/L2CrossChain/05_L2PracticalGuide/README.md",
+        "siteUrl": "https://beihaili.github.io/Get-Started-with-Web3/en/learn/module-9/9-5"
+      },
+      "excerpt": "L2 Practical Guide Four lessons of theory — now it's time to act. This lesson walks you step by step through bridging assets to L2, configuring your wallet, using DeFi, and using real Gas fee data to help you make the best chain selection decisions. Follow me on Twitter: @bhbtc1337 Join the WeChat group: Form Link Articles are open sourced on GitHub: Get Started with Web3 Recommended exchange for buying BTC / ETH / U",
+      "headings": [
+        {
+          "level": 1,
+          "text": "L2 Practical Guide"
+        },
+        {
+          "level": 2,
+          "text": "Table of Contents"
+        },
+        {
+          "level": 2,
+          "text": "Bridging Assets from Ethereum to L2"
+        },
+        {
+          "level": 3,
+          "text": "Using the Arbitrum Official Bridge"
+        },
+        {
+          "level": 3,
+          "text": "Using Third-Party Bridges for Faster Withdrawals"
+        },
+        {
+          "level": 2,
+          "text": "Adding L2 Networks to MetaMask"
+        },
+        {
+          "level": 3,
+          "text": "Method 1: One-Click via ChainList"
+        },
+        {
+          "level": 3,
+          "text": "Method 2: Manual Configuration"
+        },
+        {
+          "level": 3,
+          "text": "Method 3: Auto-Add via DApp Prompt"
+        },
+        {
+          "level": 2,
+          "text": "Using DeFi on L2"
+        },
+        {
+          "level": 3,
+          "text": "Step 1: Ensure you have ETH for Gas"
+        },
+        {
+          "level": 3,
+          "text": "Step 2: Open Uniswap"
+        },
+        {
+          "level": 3,
+          "text": "Step 3: Execute the swap"
+        },
+        {
+          "level": 3,
+          "text": "Step 4: Verify the transaction"
+        },
+        {
+          "level": 3,
+          "text": "Other Common DeFi Operations"
+        },
+        {
+          "level": 2,
+          "text": "Gas Fee Comparison"
+        },
+        {
+          "level": 3,
+          "text": "ETH Transfer"
+        },
+        {
+          "level": 3,
+          "text": "Uniswap Swap"
+        },
+        {
+          "level": 3,
+          "text": "Key Takeaway"
+        },
+        {
+          "level": 2,
+          "text": "Chain Selection Strategy"
+        },
+        {
+          "level": 3,
+          "text": "Scenario 1: DeFi Trading (Large Amounts)"
+        },
+        {
+          "level": 3,
+          "text": "Scenario 2: DeFi Trading (Small Amounts / High Frequency)"
+        },
+        {
+          "level": 3,
+          "text": "Scenario 3: NFTs and Social Apps"
+        },
+        {
+          "level": 3,
+          "text": "Scenario 4: Developers Deploying a DApp"
+        },
+        {
+          "level": 3,
+          "text": "Scenario 5: Long-Term Asset Holding (Large Amounts)"
+        },
+        {
+          "level": 3,
+          "text": "Chain Selection Decision Tree"
+        },
+        {
+          "level": 2,
+          "text": "Common Pitfalls on L2"
+        },
+        {
+          "level": 3,
+          "text": "Pitfall 1: Wrapped Token Confusion"
+        },
+        {
+          "level": 3,
+          "text": "Pitfall 2: Running Out of Gas"
+        },
+        {
+          "level": 3,
+          "text": "Pitfall 3: Sequencer Single Point of Failure"
+        },
+        {
+          "level": 3,
+          "text": "Pitfall 4: Misjudging Cross-Chain Timing"
+        },
+        {
+          "level": 3,
+          "text": "Pitfall 5: Unstable RPC Nodes"
+        },
+        {
+          "level": 3,
+          "text": "Pitfall 6: Token Approval Management Across Chains"
+        },
+        {
+          "level": 2,
+          "text": "Summary"
+        },
+        {
+          "level": 2,
+          "text": "Further Reading"
+        }
+      ],
+      "codeBlockCount": 22,
+      "characterCount": 15951
     },
     {
       "id": "zh/module-10/10-1",

--- a/public/ai/manifest.json
+++ b/public/ai/manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2026-05-09",
-  "generatedAt": "2026-05-19T07:20:59.655Z",
+  "generatedAt": "2026-05-19T10:57:56.815Z",
   "repository": {
     "name": "Get-Started-with-Web3",
     "owner": "beihaili",
@@ -14,7 +14,7 @@
   ],
   "counts": {
     "modules": 11,
-    "lessons": 108,
+    "lessons": 111,
     "glossaryEntries": 57,
     "tools": 8,
     "futurePaidTools": 2

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -4,7 +4,7 @@ This repository exposes bilingual Web3 learning content for AI agents.
 
 Source: https://github.com/beihaili/Get-Started-with-Web3
 Homepage: https://beihaili.github.io/Get-Started-with-Web3/
-Generated: 2026-05-19T07:20:59.655Z
+Generated: 2026-05-19T10:57:56.815Z
 
 ## Artifacts
 - Manifest: ai/manifest.json


### PR DESCRIPTION
## Summary
- add English lessons 9-3, 9-4, and 9-5 for the Layer 2 / cross-chain module
- regenerate AI artifacts so module 9 English availability covers lessons 9-2 through 9-5
- update the daily operations report and execution board with the #194/#195/#196 triage status

This extracts the still-needed translation content from #196 while excluding its already-merged quiz changes and duplicate lesson 9-2 file. Supersedes the merge-conflicted parts of #196.

Closes #175.

## Verification
- npm run translation:check
- npm run ai:verify
- npx prettier --check en/L2CrossChain/03_L2Ecosystem/README.md en/L2CrossChain/04_CrossChainBridges/README.md en/L2CrossChain/05_L2PracticalGuide/README.md docs/operations/2026-05-19-daily-report.md docs/strategy/2026-05-14-execution-board.md
- git diff --check
- npm run lint
- npm test
- npm run build