### PR TITLE
docs(practical-tools): add OpenChainBench under On-Chain Data Analytics

### DIFF
--- a/en/其它学习资源整理/实用工具/README.md
+++ b/en/其它学习资源整理/实用工具/README.md
@@ -194,6 +194,12 @@ ORDER BY 1 DESC
 - **Services**: Institutional-grade data, alpha discovery.
 - **Website**: [nansen.ai](https://www.nansen.ai/)
 
+**OpenChainBench** (Rating: 5/5)
+- **Purpose**: Independent open-source benchmarks for crypto infrastructure (RPC providers, gas oracles, L2 finality, bridges, prediction markets, RWA yield accuracy).
+- **Features**: 76 continuous benchmarks across 22 chains, three-region probing, CC BY 4.0 data, Prometheus-based open-source harnesses on GitHub.
+- **Coverage**: Ethereum, Arbitrum, Base, Optimism, Polygon, BNB, Avalanche, Solana, and 14 more chains.
+- **Website**: [openchainbench.com](https://openchainbench.com/)
+
 ### Block Explorers
 
 **Multi-Chain Explorer Comparison**:


### PR DESCRIPTION
## Summary

Adds [OpenChainBench](https://openchainbench.com) as a new entry in the **Data Analytics Platforms → On-Chain Data Analytics** section of `en/其它学习资源整理/实用工具/README.md`, alongside Dune Analytics, DefiLlama, Token Terminal and Nansen.

## Why it fits here

The section already curates the neutral, cross-protocol analytics platforms that Web3 developers and researchers reference. What is missing is the infrastructure layer: the RPC providers, gas oracles, L2 finality times, bridge quotes, and validator yields that everything else depends on. OpenChainBench fills that gap:

- 76 continuous benchmarks across 22 chains (Ethereum, Arbitrum, Base, Optimism, Polygon, BNB, Avalanche, Solana and 14 more)
- Data probed every minute from three regions (US East, EU West, Singapore)
- All measurements published under CC BY 4.0
- Prometheus-based open-source harnesses on GitHub
- No affiliation with any RPC provider or chain foundation (neutral by construction)

For learners going through the curriculum (Beginners → Builders → Researchers), OpenChainBench is the reference layer for infrastructure questions the other analytics platforms do not answer (which RPC is fast, which gas oracle is accurate, which L2 finalises when).

## Change

One entry added under the existing Nansen entry, following the same format used by every other tool in the section (Purpose / Features / Coverage / Website). No changes to any other section.

## Disclosure

I maintain OpenChainBench. Happy to reword, shorten, or drop the entry entirely if it does not fit the curriculum's editorial style.