### PR TITLE
docs(practical-tools): add OpenChainBench entry to zh version

### DIFF
--- a/zh/其它学习资源整理/实用工具/README.MD
+++ b/zh/其它学习资源整理/实用工具/README.MD
@@ -194,6 +194,12 @@ ORDER BY 1 DESC
 - ** 服务 **：机构级数据、 Alpha 发现。
 - ** 官网 **： [nansen.ai](https://www.nansen.ai/)
 
+**OpenChainBench** ⭐⭐⭐⭐⭐
+- ** 用途 **：加密基础设施的独立开源基准测试（RPC 服务商、Gas 预言机、L2 最终性、跨链桥、预测市场、RWA 收益率精度）。
+- ** 特色 **：覆盖 22 条链的 76 项持续基准测试、三地区探测、CC BY 4.0 数据、基于 Prometheus 的开源测试框架（GitHub 开源）。
+- ** 对象 **：以太坊、Arbitrum、Base、Optimism、Polygon、BNB、Avalanche、Solana 等 22 条链。
+- ** 官网 **： [openchainbench.com](https://openchainbench.com/)
+
 ### 🔍 区块链浏览器
 
 ** 多链浏览器对比 **：


### PR DESCRIPTION
## Summary
Add the Chinese counterpart of the OpenChainBench entry merged in #238, keeping the practical-tools doc bilingual.

## Change
- One entry added under the 链上数据分析 section in `zh/其它学习资源整理/实用工具/README.MD`, matching the English entry's format (用途/特色/对象/官网 + ⭐ rating).

## Notes
- 评分与英文版保持一致（5 星）。
- No other sections touched.