### PR TITLE
fix(ai): rank glossary term matches above body mentions

### DIFF
--- a/ai/content-index.json
+++ b/ai/content-index.json
@@ -32,7 +32,7 @@
       "preferredFirstPath": "manual sponsorship or GitHub Sponsors-supported access before x402 or Stripe"
     }
   },
-  "generatedAt": "2026-06-26T01:12:46.526Z",
+  "generatedAt": "2026-08-15T13:43:34.981Z",
   "repository": {
     "name": "Get-Started-with-Web3",
     "owner": "beihaili",
@@ -12659,7 +12659,7 @@
         }
       ],
       "codeBlockCount": 26,
-      "characterCount": 19350
+      "characterCount": 19670
     },
     {
       "id": "en/module-6/6-6",
@@ -12840,7 +12840,7 @@
         }
       ],
       "codeBlockCount": 26,
-      "characterCount": 26845
+      "characterCount": 27364
     },
     {
       "id": "zh/module-7/7-1",

--- a/ai/llms.txt
+++ b/ai/llms.txt
@@ -4,7 +4,7 @@ This repository exposes bilingual Web3 learning content for AI agents.
 
 Source: https://github.com/beihaili/Get-Started-with-Web3
 Homepage: https://bhbtc.xyz/
-Generated: 2026-06-26T01:12:46.526Z
+Generated: 2026-08-15T13:43:34.981Z
 
 ## Artifacts
 - Artifact contract: v1.0.0 (stable)

--- a/ai/manifest.json
+++ b/ai/manifest.json
@@ -32,7 +32,7 @@
       "preferredFirstPath": "manual sponsorship or GitHub Sponsors-supported access before x402 or Stripe"
     }
   },
-  "generatedAt": "2026-06-26T01:12:46.526Z",
+  "generatedAt": "2026-08-15T13:43:34.981Z",
   "repository": {
     "name": "Get-Started-with-Web3",
     "owner": "beihaili",

--- a/public/ai/content-index.json
+++ b/public/ai/content-index.json
@@ -32,7 +32,7 @@
       "preferredFirstPath": "manual sponsorship or GitHub Sponsors-supported access before x402 or Stripe"
     }
   },
-  "generatedAt": "2026-06-26T01:12:46.526Z",
+  "generatedAt": "2026-08-15T13:43:34.981Z",
   "repository": {
     "name": "Get-Started-with-Web3",
     "owner": "beihaili",
@@ -12659,7 +12659,7 @@
         }
       ],
       "codeBlockCount": 26,
-      "characterCount": 19350
+      "characterCount": 19670
     },
     {
       "id": "en/module-6/6-6",
@@ -12840,7 +12840,7 @@
         }
       ],
       "codeBlockCount": 26,
-      "characterCount": 26845
+      "characterCount": 27364
     },
     {
       "id": "zh/module-7/7-1",

--- a/public/ai/manifest.json
+++ b/public/ai/manifest.json
@@ -32,7 +32,7 @@
       "preferredFirstPath": "manual sponsorship or GitHub Sponsors-supported access before x402 or Stripe"
     }
   },
-  "generatedAt": "2026-06-26T01:12:46.526Z",
+  "generatedAt": "2026-08-15T13:43:34.981Z",
   "repository": {
     "name": "Get-Started-with-Web3",
     "owner": "beihaili",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -4,7 +4,7 @@ This repository exposes bilingual Web3 learning content for AI agents.
 
 Source: https://github.com/beihaili/Get-Started-with-Web3
 Homepage: https://bhbtc.xyz/
-Generated: 2026-06-26T01:12:46.526Z
+Generated: 2026-08-15T13:43:34.981Z
 
 ## Artifacts
 - Artifact contract: v1.0.0 (stable)

--- a/scripts/ai-content-core.mjs
+++ b/scripts/ai-content-core.mjs
@@ -349,10 +349,16 @@ export function lookupGlossary(index, options = {}) {
   const query = String(options.query || '').trim();
   const limit = clampNumber(options.limit, 5, 1, 20);
   const results = index.glossary
-    .map((entry) => ({
-      ...entry,
-      score: query ? scoreText(query, `${entry.term}\n${entry.definition}\n${entry.category}`) : 1,
-    }))
+    .map((entry) => {
+      let score = 1;
+      if (query) {
+        const termScore = scoreText(query, entry.term);
+        const bodyScore = scoreText(query, `${entry.definition}\n${entry.category}`);
+        // 术语名命中应显著高于正文命中，避免“定义里提了一嘴”的条目挤掉术语本身。
+        score = termScore ? termScore * 10 + bodyScore : bodyScore;
+      }
+      return { ...entry, score };
+    })
     .filter((entry) => entry.score > 0)
     .sort((a, b) => b.score - a.score || a.term.localeCompare(b.term))
     .slice(0, limit);


### PR DESCRIPTION
## Summary
Fix a latent `lookupGlossary` ranking bug that surfaces on Node 22.

## Problem
When querying `Gas`, `lookupGlossary` returned 「账户抽象 (Account Abstraction)」 first instead of 「Gas」, because both entries hit the same `includes('gas')` branch in `scoreText` (the former only mentions "Gas 赞助" in its definition), and the tie was broken by `localeCompare`, whose ordering differs between Node 20 and Node 22 (ICU versions). CI passes on Node 20 but fails once the planned Node 22 migration lands.

## Fix
- `lookupGlossary` now scores the term field separately and weights a term match 10× over a definition/category mention, so the term itself ranks first deterministically.
- No change to `scoreText` or the other search paths.

## Also
- Second commit regenerates `ai/` + `public/ai/` artifacts (content index, llms.txt, manifest) that were stale since 2026-06-26; course content grew in the meantime.

## Validation
- `npx vitest run scripts/__tests__/ai-content-core.test.js` ✅
- `npm test` (294 passed) ✅
- `npm run lint` ✅
