### PR TITLE
fix(security): override fast-uri to 3.1.5 for host-confusion CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4727,9 +4727,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -103,5 +103,8 @@
     "zh/**/*.{md,MD}": [
       "node scripts/format-markdown.mjs"
     ]
+  },
+  "overrides": {
+    "fast-uri": "3.1.5"
   }
 }


### PR DESCRIPTION
## Summary
Override the transitive `fast-uri` dependency to `3.1.5` to fix three high-severity host-confusion CVEs.

## Background
`fast-uri` is pulled in transitively by `ajv@8` (via `@commitlint/config-validator` and `@modelcontextprotocol/sdk`). The 3.x line is affected by three advisories:

- [GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6) (CVE-2026-13676) — fixed in 3.1.3
- [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx) — fixed in 3.1.4
- [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) — fixed in 3.1.5

## Fix
- Add `overrides: { "fast-uri": "3.1.5" }` (latest 3.x, stays within ajv's `^3.0.1` range — no major jump).
- Update the lockfile entry for `fast-uri` to 3.1.5.

This supersedes #244, which pinned 4.1.2 (breaking ajv's `^3.0.1` range) and bundled unrelated lockfile churn.

## Validation
- `npm install --package-lock-only` resolves cleanly (exit 0).
- `npm audit` high count drops 5 → 4 (all three fast-uri advisories cleared).
- JSON validity of both files confirmed.
