### PR TITLE
docs: record public API launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Use the hosted learning platform:
 Public AI entrypoints:
 
 - [REST API documentation](docs/api.md)
-- [REST API deployment target](https://get-started-with-web3.vercel.app/api/v1)
-- [OpenAPI 3.1 deployment target](https://get-started-with-web3.vercel.app/api/v1/openapi.json)
+- [Production REST API](https://get-started-with-web3.vercel.app/api/v1)
+- [Production OpenAPI 3.1 document](https://get-started-with-web3.vercel.app/api/v1/openapi.json)
 - [llms.txt](https://beihaili.github.io/Get-Started-with-Web3/llms.txt)
 - [AI manifest](https://beihaili.github.io/Get-Started-with-Web3/ai/manifest.json)
 - [AI content index](https://beihaili.github.io/Get-Started-with-Web3/ai/content-index.json)
@@ -157,7 +157,7 @@ Then connect an MCP client and use:
 
 Local MCP tools are read-only. They do not enforce payment, sign transactions, or perform chain operations. x402 fields are reserved metadata for future hosted paid tools.
 
-The REST API implementation exposes the same generated content index over versioned, cacheable JSON endpoints with no authentication. The production URLs become live after the Vercel Functions deployment is connected. See the [API documentation](docs/api.md) or the [OpenAPI deployment target](https://get-started-with-web3.vercel.app/api/v1/openapi.json).
+The REST API exposes the same generated content index over versioned, cacheable JSON endpoints with no authentication. It is live on a dedicated Vercel Functions host; `bhbtc.xyz` remains the website host and is not the API base URL. See the [API documentation](docs/api.md) or the [production OpenAPI document](https://get-started-with-web3.vercel.app/api/v1/openapi.json).
 
 AI artifacts are maintained as a stable v1 public surface through `artifactContract.version`; see [AI-native v1 stability and monetization decision](docs/strategy/2026-06-26-ai-native-v1-stability-and-monetization.md).
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,7 +4,7 @@ The Get Started with Web3 API provides free, read-only access to the project's b
 
 ## Deployment status
 
-The API implementation is ready for Vercel Functions. The production URL below is the deployment target and must return `application/json` before the API is submitted to a public directory.
+The API is live on Vercel Functions at the production URL below and returns `application/json`. The project website remains at `https://bhbtc.xyz`; its `/api/v1` path is not an API endpoint, so API clients should use the Vercel base URL.
 
 ## Base URL
 

--- a/docs/operations/2026-08-16-daily-report.md
+++ b/docs/operations/2026-08-16-daily-report.md
@@ -19,6 +19,7 @@
 - Platform:
   - Merged PR #246 and released the public, read-only REST API as Vercel Functions.
   - Published API v1, OpenAPI 3.1 documentation, bilingual lesson access, glossary search, and role-based learning paths at `https://get-started-with-web3.vercel.app/api/v1`.
+  - Confirmed the dedicated Vercel hostname as the production API base; `bhbtc.xyz` remains the website host and its `/api/v1` path is not an API endpoint.
 - External distribution:
   - Forked `public-apis/public-apis`, added one alphabetized Blockchain entry, and opened upstream PR #6891.
   - Linked the API documentation rather than the product landing page and verified the link, HTTPS, no-auth, and CORS claims against production.
@@ -53,6 +54,7 @@
 
 - Upstream PR #6891 still requires `public-apis` maintainer review and merge.
 - The upstream repository's current full-file format validator reports pre-existing baseline errors; the submitted row was checked separately and adds no new error.
+- API clients must use `get-started-with-web3.vercel.app`; moving the API behind the `bhbtc.xyz` website domain would require a separate routing or domain migration decision.
 - The API is read-only and public, so future write endpoints, authentication, rate-limit products, or payment enforcement require separate design and review.
 
 ## Next Operating Block

--- a/docs/operations/2026-08-16-daily-report.md
+++ b/docs/operations/2026-08-16-daily-report.md
@@ -1,0 +1,70 @@
+# Get Started with Web3 Daily Operations Report
+
+**Date:** 2026-08-16
+**Owner:** beihai + Codex
+**Reporting window:** Public REST API launch and external distribution, Asia/Shanghai.
+
+## KPI Snapshot
+
+| Metric | Current | Previous / Baseline | Movement | Source |
+| --- | ---: | ---: | ---: | --- |
+| GitHub stars | 612 | 614 on 2026-06-26 report | -2 | `gh repo view` |
+| Forks | 58 | 56 on 2026-06-26 report | +2 | `gh repo view` |
+| Watchers | 3 | 3 on 2026-06-26 report | 0 | `gh repo view` |
+| Open PRs | 1 | 4 on 2026-06-26 report | -3 | `gh pr list` |
+| Open issues | 14 | 14 on 2026-06-26 report | 0 | `gh issue list` |
+
+## Completed
+
+- Platform:
+  - Merged PR #246 and released the public, read-only REST API as Vercel Functions.
+  - Published API v1, OpenAPI 3.1 documentation, bilingual lesson access, glossary search, and role-based learning paths at `https://get-started-with-web3.vercel.app/api/v1`.
+- External distribution:
+  - Forked `public-apis/public-apis`, added one alphabetized Blockchain entry, and opened upstream PR #6891.
+  - Linked the API documentation rather than the product landing page and verified the link, HTTPS, no-auth, and CORS claims against production.
+- AI-native:
+  - Kept the existing static AI artifacts and read-only MCP server unchanged; the REST API exposes the same maintained content layer over HTTP.
+- Monetization:
+  - No payment, x402 enforcement, wallet action, or paid endpoint was enabled.
+
+## Deploy And Verification
+
+| Surface | Status | Evidence | Notes |
+| --- | --- | --- | --- |
+| Production deploy | Passed | Vercel status on merge commit `635ec83497f7d9d46d5c4bfdc900ab6c7ea4a49f` | Deployment completed successfully |
+| Pre-merge CI | Passed | PR #246 `build-and-deploy`, `lighthouse`, and Vercel checks | All recorded checks completed successfully |
+| Public REST smoke | Passed | `https://get-started-with-web3.vercel.app/api/v1` | Root, search, nested lesson, and OpenAPI returned JSON; invalid input, 404, OPTIONS, and unsupported method behavior also verified |
+| API transport | Passed | Production response headers | HTTPS enabled; CORS allows public reads; JSON responses expose cache policy |
+| Upstream entry validation | Passed for the submitted row | `public-apis` format helper, duplicate-link checker, live-link checker, and 31 unit tests | New row produced zero new format errors and its documentation link returned HTTP 200 |
+
+## External Distribution
+
+| Target | Status | Evidence | Next action |
+| --- | --- | --- | --- |
+| public-apis Blockchain list | PR open | https://github.com/public-apis/public-apis/pull/6891 | Monitor checks and respond to maintainer feedback |
+
+## Sponsor And Revenue
+
+| Lead / Channel | Status | Next action | Risk notes |
+| --- | --- | --- | --- |
+| Public REST API | Free public v1 launched | Observe adoption before proposing hosted paid tools | No payment enforcement or chain operations are live |
+
+## Blockers And Risks
+
+- Upstream PR #6891 still requires `public-apis` maintainer review and merge.
+- The upstream repository's current full-file format validator reports pre-existing baseline errors; the submitted row was checked separately and adds no new error.
+- The API is read-only and public, so future write endpoints, authentication, rate-limit products, or payment enforcement require separate design and review.
+
+## Next Operating Block
+
+1. Monitor and address actionable feedback on public-apis PR #6891.
+2. Announce the API listing after upstream acceptance and link directly to the API documentation.
+3. Review production request/error signals before changing API scope or monetization.
+
+## Evidence Links
+
+- Release PR: https://github.com/beihaili/Get-Started-with-Web3/pull/246
+- Production API: https://get-started-with-web3.vercel.app/api/v1
+- OpenAPI document: https://get-started-with-web3.vercel.app/api/v1/openapi.json
+- API documentation: https://github.com/beihaili/Get-Started-with-Web3/blob/main/docs/api.md
+- public-apis submission: https://github.com/public-apis/public-apis/pull/6891


### PR DESCRIPTION
## Summary

- record the production REST API launch and PR #246 merge
- record the public-apis submission and verification evidence
- clarify that the dedicated Vercel hostname is the production API base while `bhbtc.xyz` remains the website host
- capture current KPI snapshot, risks, and next actions

## Validation

- `git diff --check`
- production API, OpenAPI document, and upstream PR returned HTTP 200
- 22/22 production HTTP scenarios passed, including error, CORS, cache, method, and citation checks

Documentation-only follow-up; no runtime behavior changed.